### PR TITLE
Readme plugin

### DIFF
--- a/.plans/TODO.md
+++ b/.plans/TODO.md
@@ -10,7 +10,7 @@ Based on analysis of `_config.ts` and related custom files.
 | High | **Movie Page** - JSX page component for displaying movie data | ~80 lines | `movies/page.page.ts`, `_includes/movie.page.tsx` |
 | Medium | **Gemini Engine** - custom engine for `.gmi` file rendering | ~30 lines | `gemini.ts` |
 | Medium | **HTML→Gemtext** - post-build converter to generate Gemini format | ~300 lines | `gemini-converter.ts` |
-| Low | **README→Index** - URL transformer `README.md` → `index.html` | ~10 lines | `_data.ts` |
+| High | **README→Index** (`readme`) - URL transformer `README.md` → directory URL | ~100 lines | `readme.ts`, `mod.ts` ✅ Implemented |
 
 ## Plugin Details
 
@@ -40,8 +40,21 @@ Post-build script that:
 - Skips certain directories (e.g., `zk/`)
 - Deletes original HTML files
 
-### 5. README→Index URL Transformer (Low Priority)
-In `_data.ts` - transforms `README.md` paths to `index.html`
+### 5. README→Index Plugin (Completed ✅)
+
+Plugin files:
+- `readme.ts` - Core plugin implementation
+- `mod.ts` - Entry point with exports
+- `test/readme_test.ts` - Test suite
+- `readme-plugin-README.md` - Documentation
+
+Features implemented:
+- Uses `site.preprocess()` approach (as per plan)
+- Configurable `target` (default: `README`)
+- `exclude` and `include` options (mutually exclusive)
+- Preserves explicit URLs set in front matter
+- Supports both pretty URLs and non-pretty URLs
+- Sets `basename` to empty for clean URLs
 
 ---
 

--- a/.plans/readme.plan.md
+++ b/.plans/readme.plan.md
@@ -1,0 +1,199 @@
+# Plugin Plan: lume-plugin-readme
+
+## Overview
+
+This plugin transforms URLs of `README` files to `index.html`, enabling cleaner URLs for documentation-style sites (e.g., `README.md` becomes `/path/` instead of `/path/README/`).
+
+## Problem Statement
+
+In many projects (especially GitHub-style documentation), users have `README.md` files in directories that should be served at the directory root with pretty URLs:
+
+```text
+/docs/getting-started/README.md  →  /docs/getting-started/
+```
+
+GitHub Pages and docsify has built-in support for this.
+
+By default, Lume generates:
+```text
+/docs/getting-started/README/index.html  →  /docs/getting-started/README/
+```
+
+This plugin provides a standardized way to transform these URLs to `/docs/getting-started/`.
+
+## User Experience
+
+### Before (manual approach)
+
+In `_data.ts` at project root:
+
+```ts
+export function url(page: Lume.Page) {
+  if (page.src.path.endsWith("README")) {
+    return page.src.path.replace("README", "index") + ".html";
+  }
+}
+```
+
+### After (with plugin)
+
+```ts
+import readme from "https://deno.land/x/lume_plugin_readme/mod.ts";
+
+site.use(readme());
+```
+
+## Technical Design
+
+### Plugin Structure
+
+Following Lume's plugin pattern from [Creating plugins](https://lume.land/docs/advanced/plugins/):
+
+```ts
+import { Site } from "lume/core.ts";
+
+interface Options {
+  /** Whether to process README files (default: true) */
+  enabled?: boolean;
+}
+
+export default function (options: Options = {}) {
+  return (site: Site) => {
+    const { enabled = true } = options;
+
+    if (!enabled) return;
+
+    // Use the url() function approach via shared data
+    // See: https://lume.land/docs/creating-pages/urls/#urls-as-functions
+  };
+}
+```
+
+### Implementation Approaches
+
+#### Approach A: Shared Data with `url` Function
+
+Create a `_data.ts` that exports a `url` function. This is the current implementation in the codebase.
+
+**Pros:**
+- Simple, works with existing pattern
+- Uses Lume's built-in URL resolution
+
+**Cons:**
+- Requires placing `_data.ts` in the root or targeted directories, and this may confilict with `_data.ts` placed by the users
+- Cannot be easily configured per-directory
+
+#### Approach B: Processor Hook
+
+Use `site.preprocess()` to modify page URLs directly.
+
+**Pros:**
+- Can be applied globally with one `site.use(readme())` call
+- More flexible configuration options
+- More suitable for plugins. Fer example, `slugify_urls` also uses this approach.
+
+**Cons:**
+- May conflict with user's manual URL settings
+
+#### Approach C: Event Listener
+
+Listen to early events to modify page URLs.
+
+**Pros:**
+- Can run before other URL processing
+- Most control over the process
+
+**Cons:**
+- More complex, requires understanding Lume's event system
+
+**Decision:** Implement this feature using approach B via `site.preprocess()`.
+
+
+### Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|--------------|
+| `enabled` | `boolean` | `true` | Enable/disable the plugin |
+| `target` | `string` | `"README"` | Base filename to transform, e.g. `home`. |
+| `exclude` | `string[]` | `[]` | Paths to exclude from transformation |
+| `include` | `string[]` | `[]` | Paths to apply transformation |
+
+### Directory Scoping
+
+By default, the plugin applies to all directories. Users can scope it to specific directories by:
+
+1. Adding an `exclude` option for paths to skip.
+2. Adding an `include` option for paths to apply transformation, if this option is used, only paths specified will be applied.
+3. If both `exclude` and `include` are present, throw an error. 
+4. Wilcards are not supported in `exclude` and `include` options.
+
+
+Example - do not transform in `/docs/` and `/guides/`:
+
+```ts
+site.use(readme({
+  exclude: ["/blog/", "/guides/"],
+}));
+```
+
+## Edge Cases
+
+1. **Conflicting manual URLs**: If user explicitly sets `url` in front matter, the plugin should NOT override it. The `url` function should return `undefined` for such cases.
+
+2. **Nested READMEs**: If `/foo/README.md` and `/foo/bar/README.md` exist, both should transform to `/foo/` and `/foo/bar/` respectively.
+
+3. **Case sensitivity**: Should handle `Readme.md`, `readme.MD`, etc. (Lume normalizes this, but need to verify).
+
+4. **Index file already exists**: If both `README.md` and `index.md` exist in the same directory, index.md takes precedence.
+
+5. **Pretty URLs disabled**: If `prettyUrls: false` in config, behavior should still transform `README.md` to `index.html`.
+
+## Testing Strategy
+
+1. **Unit tests**: Test URL transformation logic in isolation
+2. **Integration tests**: Test with full Lume build
+3. **Edge cases**:
+   - Multiple README files in nested directories
+   - Mixed with explicit `url` setting
+   - With and without `prettyUrls`
+
+## File Structure
+
+```
+lume-plugin-readme/
+├── mod.ts           # Main entry point, exports plugin
+├── readme.ts        # Core transformation logic
+├── test/
+│   └── readme_test.ts
+└── README.md        # Documentation
+```
+
+## Export Interface
+
+```ts
+// mod.ts
+export { default } from "./readme.ts";
+export type { Options } from "./readme.ts";
+```
+
+## References
+
+- Lume URLs documentation: https://lume.land/docs/creating-pages/urls/
+- Lume plugin creation: https://lume.land/docs/advanced/plugins/
+- Existing pattern in `_data.ts`: `/workspace/weakish.github.com/_data.ts`
+
+## Implementation Notes
+
+- Use `site.preprocess()` with `.html` to run on all pages after they're loaded
+- Check `page.src.path` to detect target files (e.g., `README`, `home`)
+- Skip if user has set explicit `url` in front matter (`page.data.url !== undefined`)
+- Set `page.data.url` directly to the directory path with trailing slash for pretty URLs
+- For non-pretty URLs, append `.html` extension
+- The `prettyUrls` option can be checked via `site.options.prettyUrls`
+
+## Timeline
+
+- Phase 1: Core transformation logic
+- Phase 2: Options and configuration
+- Phase 3: Testing and documentation
+- Phase 4: Publish to deno.land/x or jsdelivr

--- a/_config.ts
+++ b/_config.ts
@@ -84,8 +84,6 @@ site.ignore((path) => path.startsWith("/plugins/"));
 site.use(favicon());
 site.use(purgecss());
 
-site.ignore("plugins/");
-
 site.copy("LICENSE");
 site.copy("humans.txt");
 site.copy("llms.txt");

--- a/_config.ts
+++ b/_config.ts
@@ -79,8 +79,12 @@ site.use(remark({
 site.use(resolve_urls());
 site.use(readme());
 
+site.ignore((path) => path.startsWith("/plugins/"));
+
 site.use(favicon());
 site.use(purgecss());
+
+site.ignore("plugins/");
 
 site.copy("LICENSE");
 site.copy("humans.txt");

--- a/_config.ts
+++ b/_config.ts
@@ -19,6 +19,7 @@ import transformImages from "lume/plugins/transform_images.ts";
 import textLoader from "lume/core/loaders/text.ts";
 import GeminiEngine from "./gemini.ts";
 import { customWikiLinks } from "./custom-wiki-links.ts";
+import readme from "./plugins/readme/mod.ts";
 const site = lume({
   location: new URL(Deno.env.get("MIRROR_LOCATION") ?? "https://mmap.page"),
 });
@@ -76,6 +77,7 @@ site.use(remark({
   ]],
 }));
 site.use(resolve_urls());
+site.use(readme());
 
 site.use(favicon());
 site.use(purgecss());

--- a/_data.ts
+++ b/_data.ts
@@ -1,11 +1,3 @@
 export const layout = "default.njk";
 export const type = "article";
 
-// README.md -> index.html
-export function url(page: Lume.Page) {
-  if (page.src.path.endsWith("README")) {
-    return page.src.path.replace("README", "index") + ".html";
-  } else {
-    return;
-  }
-}

--- a/humans.txt
+++ b/humans.txt
@@ -25,16 +25,8 @@ README as Index
 
 Jekyll supports using README.md as the index page.
 Lume does not support this out of the box,
-but this feature can be implemented easily with a configuration function:
-
-    // README.md -> index.html
-    export function url(page: Lume.Page) {
-        if (page.src.path.endsWith("README")) {
-            return page.src.path.replace("README", "index") + ".html";
-        } else {
-            return;
-        }
-    }
+but a Lume plugin has been implemented to handle this.
+The plugin is available at `plugins/readme/`.
 
 Wiki Links
 ----------

--- a/plugins/readme/README.md
+++ b/plugins/readme/README.md
@@ -71,6 +71,13 @@ site.use(readme({
 | `exclude` | `string[]` | `[]` | Paths to skip (must start and end with `/`) |
 | `include` | `string[]` | `[]` | Paths to process exclusively (must start and end with `/`) |
 
+## Plugin ordering
+
+Register this plugin **before** any other plugins that modify page URLs
+(e.g., `slugify_urls`). The plugin detects explicit user-set URLs by
+comparing against Lume's auto-generated default; if another preprocessor
+modifies the URL first, this detection may fail.
+
 ## Behavior
 
 - **Pretty URLs enabled (default)**: `README.md` → `/path/to/`

--- a/plugins/readme/README.md
+++ b/plugins/readme/README.md
@@ -1,6 +1,6 @@
-# lume-plugin-readme
+# readme
 
-A Lume plugin that transforms URLs of homepage files (like `README.md`) to clean directory URLs, enabling GitHub Pages-style documentation sites.
+A Lume plugin that uses `README.md` or specified page as homepage of the website, as on GitHub Pages and docsify.
 
 ## Problem
 
@@ -67,7 +67,7 @@ site.use(readme({
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `homepage` | `string[]` | `["README"]` | Ordered array of homepage basenames (case insensitive, no extensions) |
+| `homepage` | `string[]` | `["README"]` | Ordered array of homepage basenames (case insensitive, no extensions, first match wins) |
 | `exclude` | `string[]` | `[]` | Paths to skip (must start and end with `/`) |
 | `include` | `string[]` | `[]` | Paths to process exclusively (must start and end with `/`) |
 

--- a/plugins/readme/README.md
+++ b/plugins/readme/README.md
@@ -28,16 +28,17 @@ import readme from "./plugins/readme/mod.ts";
 site.use(readme());
 ```
 
-### Custom homepage filenames
+### Custom homepage basenames
 
-Specify a custom ordered array of filenames to transform:
+Specify a custom ordered array of basenames to transform:
 
 ```ts
 site.use(readme({
-  homepage: ["home.md", "index.md", "README"],
+  homepage: ["home", "index", "README"],
 }));
 ```
 
+Do not include file extensions — Lume's `srcPath` is extension-less.
 The first match in the array wins. Matching is case insensitive.
 
 ### Exclude paths
@@ -66,7 +67,7 @@ site.use(readme({
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `homepage` | `string[]` | `["readme.md", "readme.txt", "README"]` | Ordered array of homepage filenames (case insensitive) |
+| `homepage` | `string[]` | `["README"]` | Ordered array of homepage basenames (case insensitive, no extensions) |
 | `exclude` | `string[]` | `[]` | Paths to skip (must start and end with `/`) |
 | `include` | `string[]` | `[]` | Paths to process exclusively (must start and end with `/`) |
 

--- a/plugins/readme/README.md
+++ b/plugins/readme/README.md
@@ -1,0 +1,78 @@
+# lume-plugin-readme
+
+A Lume plugin that transforms URLs of homepage files (like `README.md`) to clean directory URLs, enabling GitHub Pages-style documentation sites.
+
+## Problem
+
+By default, Lume generates URLs like this:
+
+```text
+/docs/getting-started/README.md  →  /docs/getting-started/README/
+```
+
+This plugin transforms them to:
+
+```text
+/docs/getting-started/README.md  →  /docs/getting-started/
+```
+
+## Usage
+
+### Basic usage
+
+Transform all `README` files to directory URLs:
+
+```ts
+import readme from "./plugins/readme/mod.ts";
+
+site.use(readme());
+```
+
+### Custom homepage filenames
+
+Specify a custom ordered array of filenames to transform:
+
+```ts
+site.use(readme({
+  homepage: ["home.md", "index.md", "README"],
+}));
+```
+
+The first match in the array wins. Matching is case insensitive.
+
+### Exclude paths
+
+Skip transformation for specific directories:
+
+```ts
+site.use(readme({
+  exclude: ["/blog/", "/notes/"],
+}));
+```
+
+### Include only specific paths
+
+Only transform files in specified directories:
+
+```ts
+site.use(readme({
+  include: ["/docs/", "/guides/"],
+}));
+```
+
+> **Note:** `exclude` and `include` cannot be used together.
+
+## Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `homepage` | `string[]` | `["readme.md", "readme.txt", "README"]` | Ordered array of homepage filenames (case insensitive) |
+| `exclude` | `string[]` | `[]` | Paths to skip (must start and end with `/`) |
+| `include` | `string[]` | `[]` | Paths to process exclusively (must start and end with `/`) |
+
+## Behavior
+
+- **Pretty URLs enabled (default)**: `README.md` → `/path/to/`
+- **Pretty URLs disabled**: `README.md` → `/path/to/index.html`
+- **Explicit URL set**: If a page has `url` in front matter, it is preserved
+- **Nested homepage files**: Each is transformed to its parent directory URL

--- a/plugins/readme/mod.ts
+++ b/plugins/readme/mod.ts
@@ -1,0 +1,2 @@
+export { default, readme } from "./readme.ts";
+export type { Options } from "./readme.ts";

--- a/plugins/readme/readme.ts
+++ b/plugins/readme/readme.ts
@@ -65,7 +65,7 @@ export function readme(userOptions?: Options) {
   };
 }
 
-function findHomepageMatch(
+export function findHomepageMatch(
   srcPath: string,
   homepage: string[],
 ): string | null {
@@ -81,12 +81,12 @@ function findHomepageMatch(
   return null;
 }
 
-function getBasename(srcPath: string): string {
+export function getBasename(srcPath: string): string {
   const segments = srcPath.split("/").filter(Boolean);
   return segments[segments.length - 1] || srcPath;
 }
 
-function isExcluded(srcPath: string, options: Options): boolean {
+export function isExcluded(srcPath: string, options: Options): boolean {
   const pagePath = srcPath.startsWith("/") ? srcPath : "/" + srcPath;
 
   if (options.include!.length > 0) {
@@ -100,14 +100,14 @@ function isExcluded(srcPath: string, options: Options): boolean {
   return false;
 }
 
-function getDirPath(srcPath: string): string {
+export function getDirPath(srcPath: string): string {
   const lastSlash = srcPath.lastIndexOf("/");
   if (lastSlash === -1) return "/";
   const dirPath = srcPath.slice(0, lastSlash);
   return dirPath === "" ? "/" : dirPath;
 }
 
-function buildUrl(dirPath: string, prettyUrls: boolean): string {
+export function buildUrl(dirPath: string, prettyUrls: boolean): string {
   if (prettyUrls) {
     return dirPath.endsWith("/") ? dirPath : dirPath + "/";
   }

--- a/plugins/readme/readme.ts
+++ b/plugins/readme/readme.ts
@@ -55,7 +55,8 @@ export function readme(userOptions?: Options) {
         const dirPath = getDirPath(srcPath);
         const newUrl = buildUrl(dirPath, site.options.prettyUrls);
 
-        if (page.data.url === newUrl) return;
+        const autoUrl = buildUrl(srcPath, site.options.prettyUrls);
+        if (page.data.url !== autoUrl) return;
 
         page.data.url = newUrl;
         page.data.basename = "";

--- a/plugins/readme/readme.ts
+++ b/plugins/readme/readme.ts
@@ -55,7 +55,7 @@ export function readme(userOptions?: Options) {
         const dirPath = getDirPath(srcPath);
         const newUrl = buildUrl(dirPath, site.options.prettyUrls);
 
-        if (hasExplicitUrl(page, getBasename(srcPath))) return;
+        if (hasExplicitUrl(page, srcPath, site.options.prettyUrls)) return;
 
         page.data.url = newUrl;
         page.data.basename = "";
@@ -130,25 +130,18 @@ export function buildUrl(dirPath: string, prettyUrls: boolean): string {
   return dirPath.endsWith("/") ? dirPath + "index.html" : dirPath + "/index.html";
 }
 
-export function hasExplicitUrl(page: Page, basename: string): boolean {
+export function computeAutoUrl(srcPath: string, prettyUrls: boolean): string {
+  if (prettyUrls) {
+    return srcPath.startsWith("/") ? srcPath + "/" : "/" + srcPath + "/";
+  }
+  const path = srcPath.startsWith("/") ? srcPath : "/" + srcPath;
+  return path + ".html";
+}
+
+export function hasExplicitUrl(page: Page, srcPath: string, prettyUrls: boolean): boolean {
   const url = page.data.url;
-  const base = basename.toLowerCase();
-
-  // Handle pretty URL: /path/to/README/
-  if (url.endsWith("/")) {
-    const withoutTrailingSlash = url.slice(0, -1);
-    const lastSegment = withoutTrailingSlash.slice(withoutTrailingSlash.lastIndexOf("/") + 1);
-    if (lastSegment.toLowerCase() === base) return false;
-  }
-
-  // Handle non-pretty URL: /path/to/README.html
-  if (url.endsWith(".html")) {
-    const withoutHtml = url.slice(0, -5);
-    const lastSegment = withoutHtml.slice(withoutHtml.lastIndexOf("/") + 1);
-    if (lastSegment.toLowerCase() === base) return false;
-  }
-
-  return true;
+  const autoUrl = computeAutoUrl(srcPath, prettyUrls);
+  return url.toLowerCase() !== autoUrl.toLowerCase();
 }
 
 export default readme;

--- a/plugins/readme/readme.ts
+++ b/plugins/readme/readme.ts
@@ -55,7 +55,7 @@ export function readme(userOptions?: Options) {
         const dirPath = getDirPath(srcPath);
         const newUrl = buildUrl(dirPath, site.options.prettyUrls);
 
-        const autoUrl = buildUrl(srcPath, site.options.prettyUrls);
+        const autoUrl = computeAutoUrl(srcPath, site.options.prettyUrls);
         if (page.data.url !== autoUrl) return;
 
         page.data.url = newUrl;
@@ -112,6 +112,13 @@ export function buildUrl(dirPath: string, prettyUrls: boolean): string {
     return dirPath.endsWith("/") ? dirPath : dirPath + "/";
   }
   return dirPath.endsWith("/") ? dirPath + "index.html" : dirPath + "/index.html";
+}
+
+export function computeAutoUrl(srcPath: string, prettyUrls: boolean): string {
+  if (prettyUrls) {
+    return srcPath.endsWith("/") ? srcPath : srcPath + "/";
+  }
+  return srcPath.endsWith("/") ? srcPath.slice(0, -1) + ".html" : srcPath + ".html";
 }
 
 export default readme;

--- a/plugins/readme/readme.ts
+++ b/plugins/readme/readme.ts
@@ -130,6 +130,15 @@ export function buildUrl(dirPath: string, prettyUrls: boolean): string {
   return dirPath.endsWith("/") ? dirPath + "index.html" : dirPath + "/index.html";
 }
 
+/**
+ * Computes what Lume's default auto-generated URL would be for a given source path.
+ * This is used by `hasExplicitUrl` to detect whether a user has overridden the
+ * default URL in front matter or via _data files.
+ *
+ * Note: this approach assumes no other preprocessor has modified page.data.url
+ * before this plugin runs. If using plugins like slugify_urls that transform URLs,
+ * register this plugin BEFORE them in your _config.ts.
+ */
 export function computeAutoUrl(srcPath: string, prettyUrls: boolean): string {
   if (prettyUrls) {
     return srcPath.startsWith("/") ? srcPath + "/" : "/" + srcPath + "/";
@@ -138,6 +147,14 @@ export function computeAutoUrl(srcPath: string, prettyUrls: boolean): string {
   return path + ".html";
 }
 
+/**
+ * Returns true if the page's URL was explicitly set by the user (via front matter,
+ * _data files, or URL functions), false if it's Lume's auto-generated default.
+ *
+ * Detection works by comparing against the expected auto-generated URL from
+ * computeAutoUrl. This correctly handles _data inheritance, all front matter
+ * formats (YAML/JSON/TOML), and URL functions.
+ */
 export function hasExplicitUrl(page: Page, srcPath: string, prettyUrls: boolean): boolean {
   const url = page.data.url;
   const autoUrl = computeAutoUrl(srcPath, prettyUrls);

--- a/plugins/readme/readme.ts
+++ b/plugins/readme/readme.ts
@@ -58,7 +58,6 @@ export function readme(userOptions?: Options) {
         if (hasExplicitUrl(page, srcPath, site.options.prettyUrls)) return;
 
         page.data.url = newUrl;
-        page.data.basename = "";
       });
     });
   };

--- a/plugins/readme/readme.ts
+++ b/plugins/readme/readme.ts
@@ -1,0 +1,122 @@
+import { merge } from "lume/core/utils/object.ts";
+
+import type { Page } from "lume/core/file.ts";
+import type Site from "lume/core/site.ts";
+
+export interface Options {
+  /**
+   * An ordered array of homepage filenames to transform (case insensitive).
+   * The first match wins and determines what is stripped from the path.
+   * @default ["readme.md", "readme.txt", "README"]
+   */
+  homepage?: string[];
+
+  /**
+   * Paths to exclude from transformation.
+   * Paths must start with "/" and end with "/".
+   * @default []
+   */
+  exclude?: string[];
+
+  /**
+   * Paths to apply transformation exclusively.
+   * Paths must start with "/" and end with "/".
+   * Cannot be used together with `exclude`.
+   * @default []
+   */
+  include?: string[];
+}
+
+export const defaults: Options = {
+  homepage: ["readme.md", "readme.txt", "README"],
+  exclude: [],
+  include: [],
+};
+
+export function readme(userOptions?: Options) {
+  const options = merge(defaults, userOptions);
+
+  if (options.exclude!.length > 0 && options.include!.length > 0) {
+    throw new Error(
+      "readme plugin: `exclude` and `include` options cannot be used together.",
+    );
+  }
+
+  return (site: Site) => {
+    site.preprocess(function processReadme(pages: Page[]) {
+      pages.forEach((page: Page) => {
+        if (page.data._readmeProcessed) return;
+        page.data._readmeProcessed = true;
+
+        const srcPath = page.src.path;
+        const match = findHomepageMatch(srcPath, options.homepage!);
+        if (!match) return;
+
+        if (isExcluded(srcPath, options)) return;
+
+        const dirPath = getDirPath(srcPath, match);
+        const newUrl = buildUrl(dirPath, site.options.prettyUrls);
+
+        if (page.data.url === newUrl) return;
+
+        page.data.url = newUrl;
+        page.data.basename = "";
+      });
+    });
+  };
+}
+
+function findHomepageMatch(
+  srcPath: string,
+  homepage: string[],
+): string | null {
+  const basename = getBasename(srcPath);
+  const lowerBasename = basename.toLowerCase();
+
+  for (const entry of homepage) {
+    if (lowerBasename === entry.toLowerCase()) {
+      return entry;
+    }
+  }
+
+  return null;
+}
+
+function getBasename(srcPath: string): string {
+  const segments = srcPath.split("/").filter(Boolean);
+  return segments[segments.length - 1] || srcPath;
+}
+
+function isExcluded(srcPath: string, options: Options): boolean {
+  const pagePath = srcPath.startsWith("/") ? srcPath : "/" + srcPath;
+
+  if (options.include!.length > 0) {
+    return !options.include!.some((inc) => pagePath.startsWith(inc));
+  }
+
+  if (options.exclude!.length > 0) {
+    return options.exclude!.some((exc) => pagePath.startsWith(exc));
+  }
+
+  return false;
+}
+
+function getDirPath(srcPath: string, match: string): string {
+  const targetWithSlash = "/" + match;
+  const lastSlash = srcPath.lastIndexOf(targetWithSlash);
+  if (lastSlash === -1) {
+    const withoutTarget = srcPath.slice(0, -match.length);
+    return withoutTarget.endsWith("/") ? withoutTarget : withoutTarget + "/";
+  }
+  const dirPath = srcPath.slice(0, lastSlash);
+  return dirPath.endsWith("/") ? dirPath : dirPath + "/";
+}
+
+function buildUrl(dirPath: string, prettyUrls: boolean): string {
+  if (prettyUrls) {
+    return dirPath.endsWith("/") ? dirPath : dirPath + "/";
+  }
+  return dirPath.endsWith("/") ? dirPath + "index.html" : dirPath + "/index.html";
+}
+
+export default readme;

--- a/plugins/readme/readme.ts
+++ b/plugins/readme/readme.ts
@@ -46,9 +46,6 @@ export function readme(userOptions?: Options) {
   return (site: Site) => {
     site.preprocess(function processReadme(pages: Page[]) {
       pages.forEach((page: Page) => {
-        if (page.data._readmeProcessed) return;
-        page.data._readmeProcessed = true;
-
         const srcPath = page.src.path;
         const match = findHomepageMatch(srcPath, options.homepage!);
         if (!match) return;

--- a/plugins/readme/readme.ts
+++ b/plugins/readme/readme.ts
@@ -89,12 +89,12 @@ export function getBasename(srcPath: string): string {
 export function isExcluded(srcPath: string, options: Options): boolean {
   const pagePath = srcPath.startsWith("/") ? srcPath : "/" + srcPath;
 
-  if (options.include!.length > 0) {
-    return !options.include!.some((inc) => pagePath.startsWith(inc));
+  if (options.include && options.include.length > 0) {
+    return !options.include.some((inc) => pagePath.startsWith(inc));
   }
 
-  if (options.exclude!.length > 0) {
-    return options.exclude!.some((exc) => pagePath.startsWith(exc));
+  if (options.exclude && options.exclude.length > 0) {
+    return options.exclude.some((exc) => pagePath.startsWith(exc));
   }
 
   return false;

--- a/plugins/readme/readme.ts
+++ b/plugins/readme/readme.ts
@@ -55,7 +55,7 @@ export function readme(userOptions?: Options) {
 
         if (isExcluded(srcPath, options)) return;
 
-        const dirPath = getDirPath(srcPath, match);
+        const dirPath = getDirPath(srcPath);
         const newUrl = buildUrl(dirPath, site.options.prettyUrls);
 
         if (page.data.url === newUrl) return;
@@ -102,15 +102,11 @@ function isExcluded(srcPath: string, options: Options): boolean {
   return false;
 }
 
-function getDirPath(srcPath: string, match: string): string {
-  const targetWithSlash = "/" + match;
-  const lastSlash = srcPath.lastIndexOf(targetWithSlash);
-  if (lastSlash === -1) {
-    const withoutTarget = srcPath.slice(0, -match.length);
-    return withoutTarget.endsWith("/") ? withoutTarget : withoutTarget + "/";
-  }
+function getDirPath(srcPath: string): string {
+  const lastSlash = srcPath.lastIndexOf("/");
+  if (lastSlash === -1) return "/";
   const dirPath = srcPath.slice(0, lastSlash);
-  return dirPath.endsWith("/") ? dirPath : dirPath + "/";
+  return dirPath === "" ? "/" : dirPath;
 }
 
 function buildUrl(dirPath: string, prettyUrls: boolean): string {

--- a/plugins/readme/readme.ts
+++ b/plugins/readme/readme.ts
@@ -156,8 +156,14 @@ export function computeAutoUrl(srcPath: string, prettyUrls: boolean): string {
  * formats (YAML/JSON/TOML), and URL functions.
  */
 export function hasExplicitUrl(page: Page, srcPath: string, prettyUrls: boolean): boolean {
-  const url = page.data.url;
+  const url = page.data.url as string | boolean | Function | undefined;
   const autoUrl = computeAutoUrl(srcPath, prettyUrls);
+
+  if (url === undefined) return false;
+  if (url === false) return true;
+  if (typeof url === "function") return true;
+  if (typeof url !== "string") return true;
+
   return url.toLowerCase() !== autoUrl.toLowerCase();
 }
 

--- a/plugins/readme/readme.ts
+++ b/plugins/readme/readme.ts
@@ -55,8 +55,7 @@ export function readme(userOptions?: Options) {
         const dirPath = getDirPath(srcPath);
         const newUrl = buildUrl(dirPath, site.options.prettyUrls);
 
-        const autoUrl = computeAutoUrl(srcPath, site.options.prettyUrls);
-        if (page.data.url !== autoUrl) return;
+        if (hasExplicitUrl(page, getBasename(srcPath))) return;
 
         page.data.url = newUrl;
         page.data.basename = "";
@@ -90,14 +89,31 @@ export function isExcluded(srcPath: string, options: Options): boolean {
   const pagePath = srcPath.startsWith("/") ? srcPath : "/" + srcPath;
 
   if (options.include && options.include.length > 0) {
-    return !options.include.some((inc) => pagePath.startsWith(inc));
+    return !options.include.some((inc) => {
+      const normalized = normalizePath(inc);
+      return pagePath.startsWith(normalized);
+    });
   }
 
   if (options.exclude && options.exclude.length > 0) {
-    return options.exclude.some((exc) => pagePath.startsWith(exc));
+    return options.exclude.some((exc) => {
+      const normalized = normalizePath(exc);
+      return pagePath.startsWith(normalized);
+    });
   }
 
   return false;
+}
+
+function normalizePath(path: string): string {
+  let normalized = path;
+  if (!normalized.startsWith("/")) {
+    normalized = "/" + normalized;
+  }
+  if (!normalized.endsWith("/")) {
+    normalized = normalized + "/";
+  }
+  return normalized;
 }
 
 export function getDirPath(srcPath: string): string {
@@ -114,11 +130,10 @@ export function buildUrl(dirPath: string, prettyUrls: boolean): string {
   return dirPath.endsWith("/") ? dirPath + "index.html" : dirPath + "/index.html";
 }
 
-export function computeAutoUrl(srcPath: string, prettyUrls: boolean): string {
-  if (prettyUrls) {
-    return srcPath.endsWith("/") ? srcPath : srcPath + "/";
-  }
-  return srcPath.endsWith("/") ? srcPath.slice(0, -1) + ".html" : srcPath + ".html";
+function hasExplicitUrl(page: Page, basename: string): boolean {
+  const url = page.data.url.toLowerCase();
+  const base = basename.toLowerCase();
+  return !url.endsWith(base + "/") && !url.endsWith(base + ".html");
 }
 
 export default readme;

--- a/plugins/readme/readme.ts
+++ b/plugins/readme/readme.ts
@@ -104,7 +104,7 @@ export function getDirPath(srcPath: string): string {
   const lastSlash = srcPath.lastIndexOf("/");
   if (lastSlash === -1) return "/";
   const dirPath = srcPath.slice(0, lastSlash);
-  return dirPath === "" ? "/" : dirPath;
+  return dirPath === "" ? "/" : dirPath + "/";
 }
 
 export function buildUrl(dirPath: string, prettyUrls: boolean): string {

--- a/plugins/readme/readme.ts
+++ b/plugins/readme/readme.ts
@@ -64,22 +64,6 @@ export function readme(userOptions?: Options) {
   };
 }
 
-export function findHomepageMatch(
-  srcPath: string,
-  homepage: string[],
-): string | null {
-  const basename = getBasename(srcPath);
-  const lowerBasename = basename.toLowerCase();
-
-  for (const entry of homepage) {
-    if (lowerBasename === entry.toLowerCase()) {
-      return entry;
-    }
-  }
-
-  return null;
-}
-
 export function isHomepageMatch(srcPath: string, homepage: string[]): boolean {
   const basename = getBasename(srcPath);
   const lowerBasename = basename.toLowerCase();

--- a/plugins/readme/readme.ts
+++ b/plugins/readme/readme.ts
@@ -5,9 +5,10 @@ import type Site from "lume/core/site.ts";
 
 export interface Options {
   /**
-   * An ordered array of homepage filenames to transform (case insensitive).
-   * The first match wins and determines what is stripped from the path.
-   * @default ["readme.md", "readme.txt", "README"]
+   * An ordered array of homepage basenames to transform (case insensitive).
+   * Do not include file extensions — `srcPath` is extension-less.
+   * The first match wins.
+   * @default ["README"]
    */
   homepage?: string[];
 
@@ -28,7 +29,7 @@ export interface Options {
 }
 
 export const defaults: Options = {
-  homepage: ["readme.md", "readme.txt", "README"],
+  homepage: ["README"],
   exclude: [],
   include: [],
 };

--- a/plugins/readme/readme.ts
+++ b/plugins/readme/readme.ts
@@ -15,6 +15,7 @@ export interface Options {
   /**
    * Paths to exclude from transformation.
    * Paths must start with "/" and end with "/".
+   * Cannot be used together with `include`.
    * @default []
    */
   exclude?: string[];
@@ -47,15 +48,15 @@ export function readme(userOptions?: Options) {
     site.preprocess(function processReadme(pages: Page[]) {
       pages.forEach((page: Page) => {
         const srcPath = page.src.path;
-        const match = findHomepageMatch(srcPath, options.homepage!);
-        if (!match) return;
+
+        if (!isHomepageMatch(srcPath, options.homepage!)) return;
 
         if (isExcluded(srcPath, options)) return;
 
+        if (hasExplicitUrl(page, srcPath, site.options.prettyUrls)) return;
+
         const dirPath = getDirPath(srcPath);
         const newUrl = buildUrl(dirPath, site.options.prettyUrls);
-
-        if (hasExplicitUrl(page, srcPath, site.options.prettyUrls)) return;
 
         page.data.url = newUrl;
       });
@@ -77,6 +78,13 @@ export function findHomepageMatch(
   }
 
   return null;
+}
+
+export function isHomepageMatch(srcPath: string, homepage: string[]): boolean {
+  const basename = getBasename(srcPath);
+  const lowerBasename = basename.toLowerCase();
+
+  return homepage.some((entry) => lowerBasename === entry.toLowerCase());
 }
 
 export function getBasename(srcPath: string): string {

--- a/plugins/readme/readme.ts
+++ b/plugins/readme/readme.ts
@@ -130,10 +130,25 @@ export function buildUrl(dirPath: string, prettyUrls: boolean): string {
   return dirPath.endsWith("/") ? dirPath + "index.html" : dirPath + "/index.html";
 }
 
-function hasExplicitUrl(page: Page, basename: string): boolean {
-  const url = page.data.url.toLowerCase();
+export function hasExplicitUrl(page: Page, basename: string): boolean {
+  const url = page.data.url;
   const base = basename.toLowerCase();
-  return !url.endsWith(base + "/") && !url.endsWith(base + ".html");
+
+  // Handle pretty URL: /path/to/README/
+  if (url.endsWith("/")) {
+    const withoutTrailingSlash = url.slice(0, -1);
+    const lastSegment = withoutTrailingSlash.slice(withoutTrailingSlash.lastIndexOf("/") + 1);
+    if (lastSegment.toLowerCase() === base) return false;
+  }
+
+  // Handle non-pretty URL: /path/to/README.html
+  if (url.endsWith(".html")) {
+    const withoutHtml = url.slice(0, -5);
+    const lastSegment = withoutHtml.slice(withoutHtml.lastIndexOf("/") + 1);
+    if (lastSegment.toLowerCase() === base) return false;
+  }
+
+  return true;
 }
 
 export default readme;

--- a/plugins/readme/test/readme_test.ts
+++ b/plugins/readme/test/readme_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals, assertThrows } from "https://deno.land/std@0.201.0/assert/mod.ts";
-import readme, { defaults, findHomepageMatch, getBasename, getDirPath, buildUrl, isExcluded } from "../readme.ts";
+import readme, { defaults, findHomepageMatch, getBasename, getDirPath, buildUrl, isExcluded, hasExplicitUrl } from "../readme.ts";
 import type { Page } from "lume/core/file.ts";
 import type Site from "lume/core/site.ts";
 
@@ -103,6 +103,36 @@ Deno.test("isExcluded - corrected path doesn't match partial directories", () =>
   assertEquals(isExcluded("/docs-extra/README", { include: ["docs"] }), true);
 });
 
+Deno.test("hasExplicitUrl - auto-generated pretty URL", () => {
+  const page = { data: { url: "/docs/README/" } } as Page;
+  assertEquals(hasExplicitUrl(page, "README"), false);
+});
+
+Deno.test("hasExplicitUrl - auto-generated non-pretty URL", () => {
+  const page = { data: { url: "/docs/README.html" } } as Page;
+  assertEquals(hasExplicitUrl(page, "README"), false);
+});
+
+Deno.test("hasExplicitUrl - root auto-generated URL", () => {
+  const page = { data: { url: "/README/" } } as Page;
+  assertEquals(hasExplicitUrl(page, "README"), false);
+});
+
+Deno.test("hasExplicitUrl - explicit URL not matching basename", () => {
+  const page = { data: { url: "/my-custom/" } } as Page;
+  assertEquals(hasExplicitUrl(page, "README"), true);
+});
+
+Deno.test("hasExplicitUrl - URL containing basename as substring", () => {
+  const page = { data: { url: "/docs-readme/" } } as Page;
+  assertEquals(hasExplicitUrl(page, "README"), true);
+});
+
+Deno.test("hasExplicitUrl - case insensitive for auto-generated", () => {
+  const page = { data: { url: "/docs/Readme/" } } as Page;
+  assertEquals(hasExplicitUrl(page, "README"), false);
+});
+
 Deno.test("readme plugin - transforms README URLs via preprocess", () => {
   let capturedFn: (pages: { src: { path: string }; data: { url: string; basename?: string } }[]) => void;
   const site = createMockSite({
@@ -139,6 +169,41 @@ Deno.test("readme plugin - preserves explicit URLs", () => {
   capturedFn!(pages);
 
   assertEquals(pages[0].data.url, "/my-custom-path/");
+});
+
+Deno.test("readme plugin - preserves URLs containing basename as substring", () => {
+  let capturedFn: (pages: { src: { path: string }; data: { url: string; basename?: string } }[]) => void;
+  const site = createMockSite({
+    preprocessFn: (fn) => { capturedFn = fn as typeof capturedFn; },
+  });
+  const plugin = readme();
+  plugin(site as unknown as Site);
+
+  const pages = createMockPages([
+    { srcPath: "/docs/README", url: "/docs-readme/" },
+  ]);
+
+  capturedFn!(pages);
+
+  assertEquals(pages[0].data.url, "/docs-readme/");
+});
+
+Deno.test("readme plugin - preserves explicit non-pretty URLs", () => {
+  let capturedFn: (pages: { src: { path: string }; data: { url: string; basename?: string } }[]) => void;
+  const site = createMockSite({
+    prettyUrls: false,
+    preprocessFn: (fn) => { capturedFn = fn as typeof capturedFn; },
+  });
+  const plugin = readme();
+  plugin(site as unknown as Site);
+
+  const pages = createMockPages([
+    { srcPath: "/docs/custom/README", url: "/my-custom.html" },
+  ]);
+
+  capturedFn!(pages);
+
+  assertEquals(pages[0].data.url, "/my-custom.html");
 });
 
 Deno.test("readme plugin - excludes paths via preprocess", () => {

--- a/plugins/readme/test/readme_test.ts
+++ b/plugins/readme/test/readme_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals, assertThrows } from "https://deno.land/std@0.201.0/assert/mod.ts";
-import readme, { defaults, findHomepageMatch, getBasename, getDirPath, buildUrl, isExcluded, hasExplicitUrl, computeAutoUrl } from "../readme.ts";
+import readme, { defaults, findHomepageMatch, isHomepageMatch, getBasename, getDirPath, buildUrl, isExcluded, hasExplicitUrl, computeAutoUrl } from "../readme.ts";
 import type { Page } from "lume/core/file.ts";
 import type Site from "lume/core/site.ts";
 
@@ -37,6 +37,21 @@ Deno.test("findHomepageMatch - returns null for no match", () => {
 Deno.test("findHomepageMatch - ordered array first match wins", () => {
   assertEquals(findHomepageMatch("/docs/home", ["home", "README"]), "home");
   assertEquals(findHomepageMatch("/docs/README", ["home", "README"]), "README");
+});
+
+Deno.test("isHomepageMatch - matches README", () => {
+  assertEquals(isHomepageMatch("/docs/README", ["README"]), true);
+  assertEquals(isHomepageMatch("/README", ["README"]), true);
+});
+
+Deno.test("isHomepageMatch - case insensitive", () => {
+  assertEquals(isHomepageMatch("/docs/Readme", ["README"]), true);
+  assertEquals(isHomepageMatch("/docs/readme", ["README"]), true);
+});
+
+Deno.test("isHomepageMatch - returns false for no match", () => {
+  assertEquals(isHomepageMatch("/docs/about", ["README"]), false);
+  assertEquals(isHomepageMatch("/docs/index", ["README"]), false);
 });
 
 Deno.test("getBasename - extracts last segment", () => {
@@ -164,20 +179,11 @@ Deno.test("computeAutoUrl - non-pretty URLs", () => {
 });
 
 Deno.test("readme plugin - transforms README URLs via preprocess", () => {
-  let capturedFn: (pages: { src: { path: string }; data: { url: string; basename?: string } }[]) => void;
-  const site = createMockSite({
-    preprocessFn: (fn) => { capturedFn = fn as typeof capturedFn; },
-  });
-  const plugin = readme();
-  plugin(site as unknown as Site);
-
-  const pages = createMockPages([
+  const pages = runPlugin([
     { srcPath: "/docs/getting-started/README", url: "/docs/getting-started/README/" },
     { srcPath: "/README", url: "/README/" },
     { srcPath: "/zk/README", url: "/zk/README/" },
   ]);
-
-  capturedFn!(pages);
 
   assertEquals(pages[0].data.url, "/docs/getting-started/");
   assertEquals(pages[1].data.url, "/");
@@ -185,70 +191,35 @@ Deno.test("readme plugin - transforms README URLs via preprocess", () => {
 });
 
 Deno.test("readme plugin - preserves explicit URLs", () => {
-  let capturedFn: (pages: { src: { path: string }; data: { url: string; basename?: string } }[]) => void;
-  const site = createMockSite({
-    preprocessFn: (fn) => { capturedFn = fn as typeof capturedFn; },
-  });
-  const plugin = readme();
-  plugin(site as unknown as Site);
-
-  const pages = createMockPages([
+  const pages = runPlugin([
     { srcPath: "/docs/custom/README", url: "/my-custom-path/" },
   ]);
-
-  capturedFn!(pages);
 
   assertEquals(pages[0].data.url, "/my-custom-path/");
 });
 
 Deno.test("readme plugin - preserves URLs containing basename as substring", () => {
-  let capturedFn: (pages: { src: { path: string }; data: { url: string; basename?: string } }[]) => void;
-  const site = createMockSite({
-    preprocessFn: (fn) => { capturedFn = fn as typeof capturedFn; },
-  });
-  const plugin = readme();
-  plugin(site as unknown as Site);
-
-  const pages = createMockPages([
+  const pages = runPlugin([
     { srcPath: "/docs/README", url: "/docs-readme/" },
   ]);
-
-  capturedFn!(pages);
 
   assertEquals(pages[0].data.url, "/docs-readme/");
 });
 
 Deno.test("readme plugin - preserves explicit non-pretty URLs", () => {
-  let capturedFn: (pages: { src: { path: string }; data: { url: string; basename?: string } }[]) => void;
-  const site = createMockSite({
-    prettyUrls: false,
-    preprocessFn: (fn) => { capturedFn = fn as typeof capturedFn; },
-  });
-  const plugin = readme();
-  plugin(site as unknown as Site);
-
-  const pages = createMockPages([
-    { srcPath: "/docs/custom/README", url: "/my-custom.html" },
-  ]);
-
-  capturedFn!(pages);
+  const pages = runPlugin(
+    [{ srcPath: "/docs/custom/README", url: "/my-custom.html" }],
+    undefined,
+    { prettyUrls: false },
+  );
 
   assertEquals(pages[0].data.url, "/my-custom.html");
 });
 
 Deno.test("readme plugin - preserves explicit URL with basename in different path", () => {
-  let capturedFn: (pages: { src: { path: string }; data: { url: string; basename?: string } }[]) => void;
-  const site = createMockSite({
-    preprocessFn: (fn) => { capturedFn = fn as typeof capturedFn; },
-  });
-  const plugin = readme();
-  plugin(site as unknown as Site);
-
-  const pages = createMockPages([
+  const pages = runPlugin([
     { srcPath: "/foo/README", url: "/something/README/" },
   ]);
-
-  capturedFn!(pages);
 
   assertEquals(pages[0].data.url, "/something/README/");
 });
@@ -272,76 +243,41 @@ Deno.test("readme plugin - preserves url: false", () => {
 });
 
 Deno.test("readme plugin - excludes paths via preprocess", () => {
-  let capturedFn: (pages: { src: { path: string }; data: { url: string; basename?: string } }[]) => void;
-  const site = createMockSite({
-    preprocessFn: (fn) => { capturedFn = fn as typeof capturedFn; },
-  });
-  const plugin = readme({ exclude: ["/docs/"] });
-  plugin(site as unknown as Site);
-
-  const pages = createMockPages([
+  const pages = runPlugin([
     { srcPath: "/docs/README", url: "/docs/README/" },
     { srcPath: "/guides/README", url: "/guides/README/" },
-  ]);
-
-  capturedFn!(pages);
+  ], { exclude: ["/docs/"] });
 
   assertEquals(pages[0].data.url, "/docs/README/");
   assertEquals(pages[1].data.url, "/guides/");
 });
 
 Deno.test("readme plugin - includes only specified paths via preprocess", () => {
-  let capturedFn: (pages: { src: { path: string }; data: { url: string; basename?: string } }[]) => void;
-  const site = createMockSite({
-    preprocessFn: (fn) => { capturedFn = fn as typeof capturedFn; },
-  });
-  const plugin = readme({ include: ["/docs/"] });
-  plugin(site as unknown as Site);
-
-  const pages = createMockPages([
+  const pages = runPlugin([
     { srcPath: "/docs/README", url: "/docs/README/" },
     { srcPath: "/guides/README", url: "/guides/README/" },
-  ]);
-
-  capturedFn!(pages);
+  ], { include: ["/docs/"] });
 
   assertEquals(pages[0].data.url, "/docs/");
   assertEquals(pages[1].data.url, "/guides/README/");
 });
 
 Deno.test("readme plugin - pretty URLs disabled via preprocess", () => {
-  let capturedFn: (pages: { src: { path: string }; data: { url: string; basename?: string } }[]) => void;
-  const site = createMockSite({
-    prettyUrls: false,
-    preprocessFn: (fn) => { capturedFn = fn as typeof capturedFn; },
-  });
-  const plugin = readme();
-  plugin(site as unknown as Site);
-
-  const pages = createMockPages([
-    { srcPath: "/docs/README", url: "/docs/README.html" },
-  ]);
-
-  capturedFn!(pages);
+  const pages = runPlugin(
+    [{ srcPath: "/docs/README", url: "/docs/README.html" }],
+    undefined,
+    { prettyUrls: false },
+  );
 
   assertEquals(pages[0].data.url, "/docs/index.html");
 });
 
 Deno.test("readme plugin - directory name containing homepage pattern via preprocess", () => {
-  let capturedFn: (pages: { src: { path: string }; data: { url: string; basename?: string } }[]) => void;
-  const site = createMockSite({
-    preprocessFn: (fn) => { capturedFn = fn as typeof capturedFn; },
-  });
-  const plugin = readme();
-  plugin(site as unknown as Site);
-
-  const pages = createMockPages([
+  const pages = runPlugin([
     { srcPath: "/README-docs/readme", url: "/README-docs/readme/" },
     { srcPath: "/docs/README-helper/readme", url: "/docs/README-helper/readme/" },
     { srcPath: "/README/foo/readme", url: "/README/foo/readme/" },
   ]);
-
-  capturedFn!(pages);
 
   assertEquals(pages[0].data.url, "/README-docs/");
   assertEquals(pages[1].data.url, "/docs/README-helper/");
@@ -375,4 +311,24 @@ function createMockSite(config: {
       preprocessFn?.(fn as (...args: unknown[]) => void);
     },
   };
+}
+
+type PageData = { srcPath: string; url: string };
+
+function runPlugin(
+  pagesData: PageData[],
+  pluginOptions?: Parameters<typeof readme>[0],
+  siteConfig?: Parameters<typeof createMockSite>[0],
+): PageMock[] {
+  let capturedFn: (pages: PageMock[]) => void;
+  const site = createMockSite({
+    ...siteConfig,
+    preprocessFn: (fn) => { capturedFn = fn as (pages: PageMock[]) => void; },
+  });
+  const plugin = readme(pluginOptions);
+  plugin(site as unknown as Site);
+
+  const pages = createMockPages(pagesData);
+  capturedFn!(pages);
+  return pages;
 }

--- a/plugins/readme/test/readme_test.ts
+++ b/plugins/readme/test/readme_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertThrows } from "https://deno.land/std@0.201.0/assert/mod.ts";
-import readme, { defaults } from "../readme.ts";
+import readme, { defaults, findHomepageMatch, getBasename, getDirPath, buildUrl, isExcluded } from "../readme.ts";
+import type Site from "lume/core/site.ts";
 
 Deno.test("readme plugin - default options", () => {
   assertEquals(defaults.homepage, ["README"]);
@@ -17,98 +18,179 @@ Deno.test("readme plugin - throws on both exclude and include", () => {
   );
 });
 
-Deno.test("readme plugin - transforms README URLs (srcPath is extension-less)", () => {
+Deno.test("findHomepageMatch - matches README", () => {
+  assertEquals(findHomepageMatch("/docs/README", ["README"]), "README");
+  assertEquals(findHomepageMatch("/README", ["README"]), "README");
+});
+
+Deno.test("findHomepageMatch - case insensitive", () => {
+  assertEquals(findHomepageMatch("/docs/Readme", ["README"]), "README");
+  assertEquals(findHomepageMatch("/docs/readme", ["README"]), "README");
+});
+
+Deno.test("findHomepageMatch - returns null for no match", () => {
+  assertEquals(findHomepageMatch("/docs/about", ["README"]), null);
+  assertEquals(findHomepageMatch("/docs/index", ["README"]), null);
+});
+
+Deno.test("findHomepageMatch - ordered array first match wins", () => {
+  assertEquals(findHomepageMatch("/docs/home", ["home", "README"]), "home");
+  assertEquals(findHomepageMatch("/docs/README", ["home", "README"]), "README");
+});
+
+Deno.test("getBasename - extracts last segment", () => {
+  assertEquals(getBasename("/docs/README"), "README");
+  assertEquals(getBasename("/README"), "README");
+  assertEquals(getBasename("README"), "README");
+});
+
+Deno.test("getDirPath - strips last segment", () => {
+  assertEquals(getDirPath("/docs/getting-started/README"), "/docs/getting-started/");
+  assertEquals(getDirPath("/README"), "/");
+  assertEquals(getDirPath("/zk/README"), "/zk/");
+});
+
+Deno.test("getDirPath - handles directory names containing homepage pattern", () => {
+  assertEquals(getDirPath("/README-docs/readme"), "/README-docs/");
+  assertEquals(getDirPath("/docs/README-helper/readme"), "/docs/README-helper/");
+  assertEquals(getDirPath("/README/foo/readme"), "/README/foo/");
+});
+
+Deno.test("buildUrl - pretty URLs", () => {
+  assertEquals(buildUrl("/docs/", true), "/docs/");
+  assertEquals(buildUrl("/docs", true), "/docs/");
+  assertEquals(buildUrl("/", true), "/");
+});
+
+Deno.test("buildUrl - non-pretty URLs", () => {
+  assertEquals(buildUrl("/docs/", false), "/docs/index.html");
+  assertEquals(buildUrl("/docs", false), "/docs/index.html");
+  assertEquals(buildUrl("/", false), "/index.html");
+});
+
+Deno.test("isExcluded - exclude paths", () => {
+  assertEquals(isExcluded("/docs/README", { exclude: ["/docs/"] }), true);
+  assertEquals(isExcluded("/guides/README", { exclude: ["/docs/"] }), false);
+});
+
+Deno.test("isExcluded - include paths", () => {
+  assertEquals(isExcluded("/docs/README", { include: ["/docs/"] }), false);
+  assertEquals(isExcluded("/guides/README", { include: ["/docs/"] }), true);
+});
+
+Deno.test("isExcluded - no rules", () => {
+  assertEquals(isExcluded("/docs/README", {}), false);
+});
+
+Deno.test("readme plugin - transforms README URLs via preprocess", () => {
+  let capturedFn: (pages: { src: { path: string }; data: { url: string; basename?: string } }[]) => void;
+  const site = createMockSite({
+    preprocessFn: (fn) => { capturedFn = fn as typeof capturedFn; },
+  });
+  const plugin = readme();
+  plugin(site as unknown as Site);
+
   const pages = createMockPages([
     { srcPath: "/docs/getting-started/README", url: "/docs/getting-started/README/" },
     { srcPath: "/README", url: "/README/" },
     { srcPath: "/zk/README", url: "/zk/README/" },
   ]);
 
-  applyReadmeTransform(pages, { prettyUrls: true });
+  capturedFn!(pages);
 
   assertEquals(pages[0].data.url, "/docs/getting-started/");
   assertEquals(pages[1].data.url, "/");
   assertEquals(pages[2].data.url, "/zk/");
 });
 
-Deno.test("readme plugin - case insensitive match", () => {
+Deno.test("readme plugin - preserves explicit URLs", () => {
+  let capturedFn: (pages: { src: { path: string }; data: { url: string; basename?: string } }[]) => void;
+  const site = createMockSite({
+    preprocessFn: (fn) => { capturedFn = fn as typeof capturedFn; },
+  });
+  const plugin = readme();
+  plugin(site as unknown as Site);
+
   const pages = createMockPages([
-    { srcPath: "/docs/Readme", url: "/docs/Readme/" },
-    { srcPath: "/docs/readme", url: "/docs/readme/" },
+    { srcPath: "/docs/custom/README", url: "/my-custom-path/" },
   ]);
 
-  applyReadmeTransform(pages, { prettyUrls: true });
+  capturedFn!(pages);
 
-  assertEquals(pages[0].data.url, "/docs/");
-  assertEquals(pages[1].data.url, "/docs/");
+  assertEquals(pages[0].data.url, "/my-custom-path/");
 });
 
-Deno.test("readme plugin - excludes paths", () => {
+Deno.test("readme plugin - excludes paths via preprocess", () => {
+  let capturedFn: (pages: { src: { path: string }; data: { url: string; basename?: string } }[]) => void;
+  const site = createMockSite({
+    preprocessFn: (fn) => { capturedFn = fn as typeof capturedFn; },
+  });
+  const plugin = readme({ exclude: ["/docs/"] });
+  plugin(site as unknown as Site);
+
   const pages = createMockPages([
     { srcPath: "/docs/README", url: "/docs/README/" },
     { srcPath: "/guides/README", url: "/guides/README/" },
   ]);
 
-  applyReadmeTransform(pages, { exclude: ["/docs/"] });
+  capturedFn!(pages);
 
   assertEquals(pages[0].data.url, "/docs/README/");
   assertEquals(pages[1].data.url, "/guides/");
 });
 
-Deno.test("readme plugin - includes only specified paths", () => {
+Deno.test("readme plugin - includes only specified paths via preprocess", () => {
+  let capturedFn: (pages: { src: { path: string }; data: { url: string; basename?: string } }[]) => void;
+  const site = createMockSite({
+    preprocessFn: (fn) => { capturedFn = fn as typeof capturedFn; },
+  });
+  const plugin = readme({ include: ["/docs/"] });
+  plugin(site as unknown as Site);
+
   const pages = createMockPages([
     { srcPath: "/docs/README", url: "/docs/README/" },
     { srcPath: "/guides/README", url: "/guides/README/" },
   ]);
 
-  applyReadmeTransform(pages, { include: ["/docs/"] });
+  capturedFn!(pages);
 
   assertEquals(pages[0].data.url, "/docs/");
   assertEquals(pages[1].data.url, "/guides/README/");
 });
 
-Deno.test("readme plugin - pretty URLs disabled", () => {
+Deno.test("readme plugin - pretty URLs disabled via preprocess", () => {
+  let capturedFn: (pages: { src: { path: string }; data: { url: string; basename?: string } }[]) => void;
+  const site = createMockSite({
+    prettyUrls: false,
+    preprocessFn: (fn) => { capturedFn = fn as typeof capturedFn; },
+  });
+  const plugin = readme();
+  plugin(site as unknown as Site);
+
   const pages = createMockPages([
-    { srcPath: "/docs/README", url: "/docs/README/" },
+    { srcPath: "/docs/README", url: "/docs/README/index.html" },
   ]);
 
-  applyReadmeTransform(pages, { prettyUrls: false });
+  capturedFn!(pages);
 
   assertEquals(pages[0].data.url, "/docs/index.html");
 });
 
-Deno.test("readme plugin - custom homepage array", () => {
-  const pages = createMockPages([
-    { srcPath: "/docs/home", url: "/docs/home/" },
-    { srcPath: "/docs/README", url: "/docs/README/" },
-  ]);
+Deno.test("readme plugin - directory name containing homepage pattern via preprocess", () => {
+  let capturedFn: (pages: { src: { path: string }; data: { url: string; basename?: string } }[]) => void;
+  const site = createMockSite({
+    preprocessFn: (fn) => { capturedFn = fn as typeof capturedFn; },
+  });
+  const plugin = readme();
+  plugin(site as unknown as Site);
 
-  applyReadmeTransform(pages, { homepage: ["home"] });
-
-  assertEquals(pages[0].data.url, "/docs/");
-  assertEquals(pages[1].data.url, "/docs/README/");
-});
-
-Deno.test("readme plugin - ordered array first match wins", () => {
-  const pages = createMockPages([
-    { srcPath: "/docs/README", url: "/docs/README/" },
-    { srcPath: "/docs/HOME", url: "/docs/HOME/" },
-  ]);
-
-  applyReadmeTransform(pages, { homepage: ["HOME", "README"] });
-
-  assertEquals(pages[0].data.url, "/docs/");
-  assertEquals(pages[1].data.url, "/docs/");
-});
-
-Deno.test("readme plugin - directory name containing homepage pattern", () => {
   const pages = createMockPages([
     { srcPath: "/README-docs/readme", url: "/README-docs/readme/" },
     { srcPath: "/docs/README-helper/readme", url: "/docs/README-helper/readme/" },
     { srcPath: "/README/foo/readme", url: "/README/foo/readme/" },
   ]);
 
-  applyReadmeTransform(pages, { prettyUrls: true });
+  capturedFn!(pages);
 
   assertEquals(pages[0].data.url, "/README-docs/");
   assertEquals(pages[1].data.url, "/docs/README-helper/");
@@ -127,69 +209,18 @@ function createMockPages(pagesData: { srcPath: string; url: string }[]): PageMoc
   }));
 }
 
-function applyReadmeTransform(
-  pages: PageMock[],
-  options: { prettyUrls?: boolean; homepage?: string[]; exclude?: string[]; include?: string[] } = {},
-) {
-  const {
-    prettyUrls = true,
-    homepage = ["README"],
-    exclude = [],
-    include = [],
-  } = options;
-
-  for (const page of pages) {
-    const srcPath = page.src.path;
-    const match = findHomepageMatch(srcPath, homepage);
-    if (!match) continue;
-
-    if (include.length > 0 && !include.some((inc) => {
-      const pagePath = srcPath.startsWith("/") ? srcPath : "/" + srcPath;
-      return pagePath.startsWith(inc);
-    })) continue;
-    if (exclude.length > 0) {
-      const pagePath = srcPath.startsWith("/") ? srcPath : "/" + srcPath;
-      if (exclude.some((exc) => pagePath.startsWith(exc))) continue;
-    }
-
-    const dirPath = getDirPath(srcPath);
-    const newUrl = buildUrl(dirPath, prettyUrls);
-
-    if (page.data.url === newUrl) continue;
-
-    page.data.url = newUrl;
-    page.data.basename = "";
-  }
-}
-
-function findHomepageMatch(srcPath: string, homepage: string[]): string | null {
-  const basename = getBasename(srcPath);
-  const lowerBasename = basename.toLowerCase();
-
-  for (const entry of homepage) {
-    if (lowerBasename === entry.toLowerCase()) {
-      return entry;
-    }
-  }
-
-  return null;
-}
-
-function getBasename(srcPath: string): string {
-  const segments = srcPath.split("/").filter(Boolean);
-  return segments[segments.length - 1] || srcPath;
-}
-
-function getDirPath(srcPath: string): string {
-  const lastSlash = srcPath.lastIndexOf("/");
-  if (lastSlash === -1) return "/";
-  const dirPath = srcPath.slice(0, lastSlash);
-  return dirPath === "" ? "/" : dirPath;
-}
-
-function buildUrl(dirPath: string, prettyUrls: boolean): string {
-  if (prettyUrls) {
-    return dirPath.endsWith("/") ? dirPath : dirPath + "/";
-  }
-  return dirPath.endsWith("/") ? dirPath + "index.html" : dirPath + "/index.html";
+function createMockSite(config: {
+  prettyUrls?: boolean;
+  preprocessFn?: (fn: (...args: unknown[]) => void) => void;
+} = {}) {
+  return {
+    options: {
+      prettyUrls: true,
+      ...config,
+    },
+    preprocess(...args: unknown[]) {
+      const fn = typeof args[0] === "function" ? args[0] : args[1];
+      config.preprocessFn?.(fn as (...args: unknown[]) => void);
+    },
+  };
 }

--- a/plugins/readme/test/readme_test.ts
+++ b/plugins/readme/test/readme_test.ts
@@ -101,16 +101,18 @@ Deno.test("readme plugin - ordered array first match wins", () => {
   assertEquals(pages[1].data.url, "/docs/");
 });
 
-Deno.test("readme plugin - skips non-matching source paths", () => {
+Deno.test("readme plugin - directory name containing homepage pattern", () => {
   const pages = createMockPages([
-    { srcPath: "/docs/about", url: "/docs/about/" },
-    { srcPath: "/docs/index.html", url: "/docs/index.html/" },
+    { srcPath: "/README-docs/readme", url: "/README-docs/readme/" },
+    { srcPath: "/docs/README-helper/readme", url: "/docs/README-helper/readme/" },
+    { srcPath: "/README/foo/readme", url: "/README/foo/readme/" },
   ]);
 
-  applyReadmeTransform(pages);
+  applyReadmeTransform(pages, { prettyUrls: true });
 
-  assertEquals(pages[0].data.url, "/docs/about/");
-  assertEquals(pages[1].data.url, "/docs/index.html/");
+  assertEquals(pages[0].data.url, "/README-docs/");
+  assertEquals(pages[1].data.url, "/docs/README-helper/");
+  assertEquals(pages[2].data.url, "/README/foo/");
 });
 
 interface PageMock {
@@ -150,7 +152,7 @@ function applyReadmeTransform(
       if (exclude.some((exc) => pagePath.startsWith(exc))) continue;
     }
 
-    const dirPath = getDirPath(srcPath, match);
+    const dirPath = getDirPath(srcPath);
     const newUrl = buildUrl(dirPath, prettyUrls);
 
     if (page.data.url === newUrl) continue;
@@ -178,15 +180,11 @@ function getBasename(srcPath: string): string {
   return segments[segments.length - 1] || srcPath;
 }
 
-function getDirPath(srcPath: string, match: string): string {
-  const targetWithSlash = "/" + match;
-  const lastSlash = srcPath.lastIndexOf(targetWithSlash);
-  if (lastSlash === -1) {
-    const withoutTarget = srcPath.slice(0, -match.length);
-    return withoutTarget.endsWith("/") ? withoutTarget : withoutTarget + "/";
-  }
+function getDirPath(srcPath: string): string {
+  const lastSlash = srcPath.lastIndexOf("/");
+  if (lastSlash === -1) return "/";
   const dirPath = srcPath.slice(0, lastSlash);
-  return dirPath.endsWith("/") ? dirPath : dirPath + "/";
+  return dirPath === "" ? "/" : dirPath;
 }
 
 function buildUrl(dirPath: string, prettyUrls: boolean): string {

--- a/plugins/readme/test/readme_test.ts
+++ b/plugins/readme/test/readme_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertThrows } from "https://deno.land/std@0.201.0/assert/mod.ts";
-import readme, { defaults, findHomepageMatch, getBasename, getDirPath, buildUrl, isExcluded, computeAutoUrl } from "../readme.ts";
+import readme, { defaults, findHomepageMatch, getBasename, getDirPath, buildUrl, isExcluded } from "../readme.ts";
+import type { Page } from "lume/core/file.ts";
 import type Site from "lume/core/site.ts";
 
 Deno.test("readme plugin - default options", () => {
@@ -82,14 +83,24 @@ Deno.test("isExcluded - no rules", () => {
   assertEquals(isExcluded("/docs/README", {}), false);
 });
 
-Deno.test("computeAutoUrl - pretty URLs", () => {
-  assertEquals(computeAutoUrl("/docs/README", true), "/docs/README/");
-  assertEquals(computeAutoUrl("/README", true), "/README/");
+Deno.test("isExcluded - auto-corrects missing leading slash", () => {
+  assertEquals(isExcluded("/docs/README", { exclude: ["docs/"] }), true);
+  assertEquals(isExcluded("/docs/README", { include: ["docs/"] }), false);
 });
 
-Deno.test("computeAutoUrl - non-pretty URLs", () => {
-  assertEquals(computeAutoUrl("/docs/README", false), "/docs/README.html");
-  assertEquals(computeAutoUrl("/README", false), "/README.html");
+Deno.test("isExcluded - auto-corrects missing trailing slash", () => {
+  assertEquals(isExcluded("/docs/README", { exclude: ["/docs"] }), true);
+  assertEquals(isExcluded("/docs/README", { include: ["/docs"] }), false);
+});
+
+Deno.test("isExcluded - auto-corrects missing both slashes", () => {
+  assertEquals(isExcluded("/docs/README", { exclude: ["docs"] }), true);
+  assertEquals(isExcluded("/docs/README", { include: ["docs"] }), false);
+});
+
+Deno.test("isExcluded - corrected path doesn't match partial directories", () => {
+  assertEquals(isExcluded("/docs-extra/README", { exclude: ["docs"] }), false);
+  assertEquals(isExcluded("/docs-extra/README", { include: ["docs"] }), true);
 });
 
 Deno.test("readme plugin - transforms README URLs via preprocess", () => {

--- a/plugins/readme/test/readme_test.ts
+++ b/plugins/readme/test/readme_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals, assertThrows } from "https://deno.land/std@0.201.0/assert/mod.ts";
-import readme, { defaults, findHomepageMatch, isHomepageMatch, getBasename, getDirPath, buildUrl, isExcluded, hasExplicitUrl, computeAutoUrl } from "../readme.ts";
+import readme, { defaults, isHomepageMatch, getBasename, getDirPath, buildUrl, isExcluded, hasExplicitUrl, computeAutoUrl } from "../readme.ts";
 import type { Page } from "lume/core/file.ts";
 import type Site from "lume/core/site.ts";
 
@@ -17,26 +17,6 @@ Deno.test("readme plugin - throws on both exclude and include", () => {
     Error,
     "`exclude` and `include` options cannot be used together",
   );
-});
-
-Deno.test("findHomepageMatch - matches README", () => {
-  assertEquals(findHomepageMatch("/docs/README", ["README"]), "README");
-  assertEquals(findHomepageMatch("/README", ["README"]), "README");
-});
-
-Deno.test("findHomepageMatch - case insensitive", () => {
-  assertEquals(findHomepageMatch("/docs/Readme", ["README"]), "README");
-  assertEquals(findHomepageMatch("/docs/readme", ["README"]), "README");
-});
-
-Deno.test("findHomepageMatch - returns null for no match", () => {
-  assertEquals(findHomepageMatch("/docs/about", ["README"]), null);
-  assertEquals(findHomepageMatch("/docs/index", ["README"]), null);
-});
-
-Deno.test("findHomepageMatch - ordered array first match wins", () => {
-  assertEquals(findHomepageMatch("/docs/home", ["home", "README"]), "home");
-  assertEquals(findHomepageMatch("/docs/README", ["home", "README"]), "README");
 });
 
 Deno.test("isHomepageMatch - matches README", () => {

--- a/plugins/readme/test/readme_test.ts
+++ b/plugins/readme/test/readme_test.ts
@@ -1,0 +1,207 @@
+import { assertEquals, assertThrows } from "https://deno.land/std@0.201.0/assert/mod.ts";
+import readme, { defaults } from "../readme.ts";
+
+Deno.test("readme plugin - default options", () => {
+  assertEquals(defaults.homepage, ["readme.md", "readme.txt", "README"]);
+  assertEquals(defaults.exclude, []);
+  assertEquals(defaults.include, []);
+});
+
+Deno.test("readme plugin - throws on both exclude and include", () => {
+  assertThrows(
+    () => {
+      readme({ exclude: ["/docs/"], include: ["/guides/"] });
+    },
+    Error,
+    "`exclude` and `include` options cannot be used together",
+  );
+});
+
+Deno.test("readme plugin - transforms README URLs", () => {
+  const pages = createMockPages([
+    { srcPath: "/docs/getting-started/README", url: "/docs/getting-started/README/" },
+    { srcPath: "/README", url: "/README/" },
+    { srcPath: "/zk/README", url: "/zk/README/" },
+  ]);
+
+  applyReadmeTransform(pages, { prettyUrls: true });
+
+  assertEquals(pages[0].data.url, "/docs/getting-started/");
+  assertEquals(pages[1].data.url, "/");
+  assertEquals(pages[2].data.url, "/zk/");
+});
+
+Deno.test("readme plugin - transforms README.md URLs", () => {
+  const pages = createMockPages([
+    { srcPath: "/docs/README.md", url: "/docs/README.md/" },
+    { srcPath: "/README.md", url: "/README.md/" },
+  ]);
+
+  applyReadmeTransform(pages, { prettyUrls: true });
+
+  assertEquals(pages[0].data.url, "/docs/");
+  assertEquals(pages[1].data.url, "/");
+});
+
+Deno.test("readme plugin - case insensitive match", () => {
+  const pages = createMockPages([
+    { srcPath: "/docs/Readme.md", url: "/docs/Readme.md/" },
+    { srcPath: "/docs/readme.MD", url: "/docs/readme.MD/" },
+  ]);
+
+  applyReadmeTransform(pages, { prettyUrls: true });
+
+  assertEquals(pages[0].data.url, "/docs/");
+  assertEquals(pages[1].data.url, "/docs/");
+});
+
+Deno.test("readme plugin - excludes paths", () => {
+  const pages = createMockPages([
+    { srcPath: "/docs/README", url: "/docs/README/" },
+    { srcPath: "/guides/README", url: "/guides/README/" },
+  ]);
+
+  applyReadmeTransform(pages, { exclude: ["/docs/"] });
+
+  assertEquals(pages[0].data.url, "/docs/README/");
+  assertEquals(pages[1].data.url, "/guides/");
+});
+
+Deno.test("readme plugin - includes only specified paths", () => {
+  const pages = createMockPages([
+    { srcPath: "/docs/README", url: "/docs/README/" },
+    { srcPath: "/guides/README", url: "/guides/README/" },
+  ]);
+
+  applyReadmeTransform(pages, { include: ["/docs/"] });
+
+  assertEquals(pages[0].data.url, "/docs/");
+  assertEquals(pages[1].data.url, "/guides/README/");
+});
+
+Deno.test("readme plugin - pretty URLs disabled", () => {
+  const pages = createMockPages([
+    { srcPath: "/docs/README", url: "/docs/README/" },
+  ]);
+
+  applyReadmeTransform(pages, { prettyUrls: false });
+
+  assertEquals(pages[0].data.url, "/docs/index.html");
+});
+
+Deno.test("readme plugin - custom homepage array", () => {
+  const pages = createMockPages([
+    { srcPath: "/docs/home", url: "/docs/home/" },
+    { srcPath: "/docs/README", url: "/docs/README/" },
+  ]);
+
+  applyReadmeTransform(pages, { homepage: ["home"] });
+
+  assertEquals(pages[0].data.url, "/docs/");
+  assertEquals(pages[1].data.url, "/docs/README/");
+});
+
+Deno.test("readme plugin - ordered array first match wins", () => {
+  const pages = createMockPages([
+    { srcPath: "/docs/README", url: "/docs/README/" },
+  ]);
+
+  applyReadmeTransform(pages, { homepage: ["README.md", "README"] });
+
+  assertEquals(pages[0].data.url, "/docs/");
+});
+
+Deno.test("readme plugin - skips non-matching source paths", () => {
+  const pages = createMockPages([
+    { srcPath: "/docs/about", url: "/docs/about/" },
+    { srcPath: "/docs/index.html", url: "/docs/index.html/" },
+  ]);
+
+  applyReadmeTransform(pages);
+
+  assertEquals(pages[0].data.url, "/docs/about/");
+  assertEquals(pages[1].data.url, "/docs/index.html/");
+});
+
+interface PageMock {
+  src: { path: string };
+  data: { url: string; basename?: string };
+}
+
+function createMockPages(pagesData: { srcPath: string; url: string }[]): PageMock[] {
+  return pagesData.map(({ srcPath, url }) => ({
+    src: { path: srcPath },
+    data: { url },
+  }));
+}
+
+function applyReadmeTransform(
+  pages: PageMock[],
+  options: { prettyUrls?: boolean; homepage?: string[]; exclude?: string[]; include?: string[] } = {},
+) {
+  const {
+    prettyUrls = true,
+    homepage = ["readme.md", "readme.txt", "README"],
+    exclude = [],
+    include = [],
+  } = options;
+
+  for (const page of pages) {
+    const srcPath = page.src.path;
+    const match = findHomepageMatch(srcPath, homepage);
+    if (!match) continue;
+
+    if (include.length > 0 && !include.some((inc) => {
+      const pagePath = srcPath.startsWith("/") ? srcPath : "/" + srcPath;
+      return pagePath.startsWith(inc);
+    })) continue;
+    if (exclude.length > 0) {
+      const pagePath = srcPath.startsWith("/") ? srcPath : "/" + srcPath;
+      if (exclude.some((exc) => pagePath.startsWith(exc))) continue;
+    }
+
+    const dirPath = getDirPath(srcPath, match);
+    const newUrl = buildUrl(dirPath, prettyUrls);
+
+    if (page.data.url === newUrl) continue;
+
+    page.data.url = newUrl;
+    page.data.basename = "";
+  }
+}
+
+function findHomepageMatch(srcPath: string, homepage: string[]): string | null {
+  const basename = getBasename(srcPath);
+  const lowerBasename = basename.toLowerCase();
+
+  for (const entry of homepage) {
+    if (lowerBasename === entry.toLowerCase()) {
+      return entry;
+    }
+  }
+
+  return null;
+}
+
+function getBasename(srcPath: string): string {
+  const segments = srcPath.split("/").filter(Boolean);
+  return segments[segments.length - 1] || srcPath;
+}
+
+function getDirPath(srcPath: string, match: string): string {
+  const targetWithSlash = "/" + match;
+  const lastSlash = srcPath.lastIndexOf(targetWithSlash);
+  if (lastSlash === -1) {
+    const withoutTarget = srcPath.slice(0, -match.length);
+    return withoutTarget.endsWith("/") ? withoutTarget : withoutTarget + "/";
+  }
+  const dirPath = srcPath.slice(0, lastSlash);
+  return dirPath.endsWith("/") ? dirPath : dirPath + "/";
+}
+
+function buildUrl(dirPath: string, prettyUrls: boolean): string {
+  if (prettyUrls) {
+    return dirPath.endsWith("/") ? dirPath : dirPath + "/";
+  }
+  return dirPath.endsWith("/") ? dirPath + "index.html" : dirPath + "/index.html";
+}

--- a/plugins/readme/test/readme_test.ts
+++ b/plugins/readme/test/readme_test.ts
@@ -133,6 +133,21 @@ Deno.test("hasExplicitUrl - explicit URL with basename but different path", () =
   assertEquals(hasExplicitUrl(page, "/foo/README", true), true);
 });
 
+Deno.test("hasExplicitUrl - url set to false", () => {
+  const page = { data: { url: false } } as unknown as Page;
+  assertEquals(hasExplicitUrl(page, "/docs/README", true), true);
+});
+
+Deno.test("hasExplicitUrl - url is a function", () => {
+  const page = { data: { url: () => "/custom/" } } as unknown as Page;
+  assertEquals(hasExplicitUrl(page, "/docs/README", true), true);
+});
+
+Deno.test("hasExplicitUrl - url is undefined", () => {
+  const page = { data: {} } as Page;
+  assertEquals(hasExplicitUrl(page, "/docs/README", true), false);
+});
+
 Deno.test("hasExplicitUrl - case insensitive for auto-generated", () => {
   const page = { data: { url: "/docs/Readme/" } } as Page;
   assertEquals(hasExplicitUrl(page, "/docs/README", true), false);
@@ -236,6 +251,24 @@ Deno.test("readme plugin - preserves explicit URL with basename in different pat
   capturedFn!(pages);
 
   assertEquals(pages[0].data.url, "/something/README/");
+});
+
+Deno.test("readme plugin - preserves url: false", () => {
+  let capturedFn: (pages: { src: { path: string }; data: { url: unknown; basename?: string } }[]) => void;
+  const site = createMockSite({
+    preprocessFn: (fn) => { capturedFn = fn as typeof capturedFn; },
+  });
+  const plugin = readme();
+  plugin(site as unknown as Site);
+
+  const pages = [{
+    src: { path: "/docs/README" },
+    data: { url: false },
+  }];
+
+  capturedFn!(pages);
+
+  assertEquals(pages[0].data.url, false);
 });
 
 Deno.test("readme plugin - excludes paths via preprocess", () => {

--- a/plugins/readme/test/readme_test.ts
+++ b/plugins/readme/test/readme_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals, assertThrows } from "https://deno.land/std@0.201.0/assert/mod.ts";
-import readme, { defaults, findHomepageMatch, getBasename, getDirPath, buildUrl, isExcluded } from "../readme.ts";
+import readme, { defaults, findHomepageMatch, getBasename, getDirPath, buildUrl, isExcluded, computeAutoUrl } from "../readme.ts";
 import type Site from "lume/core/site.ts";
 
 Deno.test("readme plugin - default options", () => {
@@ -80,6 +80,16 @@ Deno.test("isExcluded - include paths", () => {
 
 Deno.test("isExcluded - no rules", () => {
   assertEquals(isExcluded("/docs/README", {}), false);
+});
+
+Deno.test("computeAutoUrl - pretty URLs", () => {
+  assertEquals(computeAutoUrl("/docs/README", true), "/docs/README/");
+  assertEquals(computeAutoUrl("/README", true), "/README/");
+});
+
+Deno.test("computeAutoUrl - non-pretty URLs", () => {
+  assertEquals(computeAutoUrl("/docs/README", false), "/docs/README.html");
+  assertEquals(computeAutoUrl("/README", false), "/README.html");
 });
 
 Deno.test("readme plugin - transforms README URLs via preprocess", () => {
@@ -168,7 +178,7 @@ Deno.test("readme plugin - pretty URLs disabled via preprocess", () => {
   plugin(site as unknown as Site);
 
   const pages = createMockPages([
-    { srcPath: "/docs/README", url: "/docs/README/index.html" },
+    { srcPath: "/docs/README", url: "/docs/README.html" },
   ]);
 
   capturedFn!(pages);
@@ -213,14 +223,15 @@ function createMockSite(config: {
   prettyUrls?: boolean;
   preprocessFn?: (fn: (...args: unknown[]) => void) => void;
 } = {}) {
+  const { prettyUrls, preprocessFn } = config;
   return {
     options: {
       prettyUrls: true,
-      ...config,
+      ...prettyUrls !== undefined && { prettyUrls },
     },
     preprocess(...args: unknown[]) {
       const fn = typeof args[0] === "function" ? args[0] : args[1];
-      config.preprocessFn?.(fn as (...args: unknown[]) => void);
+      preprocessFn?.(fn as (...args: unknown[]) => void);
     },
   };
 }

--- a/plugins/readme/test/readme_test.ts
+++ b/plugins/readme/test/readme_test.ts
@@ -2,7 +2,7 @@ import { assertEquals, assertThrows } from "https://deno.land/std@0.201.0/assert
 import readme, { defaults } from "../readme.ts";
 
 Deno.test("readme plugin - default options", () => {
-  assertEquals(defaults.homepage, ["readme.md", "readme.txt", "README"]);
+  assertEquals(defaults.homepage, ["README"]);
   assertEquals(defaults.exclude, []);
   assertEquals(defaults.include, []);
 });
@@ -17,7 +17,7 @@ Deno.test("readme plugin - throws on both exclude and include", () => {
   );
 });
 
-Deno.test("readme plugin - transforms README URLs", () => {
+Deno.test("readme plugin - transforms README URLs (srcPath is extension-less)", () => {
   const pages = createMockPages([
     { srcPath: "/docs/getting-started/README", url: "/docs/getting-started/README/" },
     { srcPath: "/README", url: "/README/" },
@@ -31,22 +31,10 @@ Deno.test("readme plugin - transforms README URLs", () => {
   assertEquals(pages[2].data.url, "/zk/");
 });
 
-Deno.test("readme plugin - transforms README.md URLs", () => {
-  const pages = createMockPages([
-    { srcPath: "/docs/README.md", url: "/docs/README.md/" },
-    { srcPath: "/README.md", url: "/README.md/" },
-  ]);
-
-  applyReadmeTransform(pages, { prettyUrls: true });
-
-  assertEquals(pages[0].data.url, "/docs/");
-  assertEquals(pages[1].data.url, "/");
-});
-
 Deno.test("readme plugin - case insensitive match", () => {
   const pages = createMockPages([
-    { srcPath: "/docs/Readme.md", url: "/docs/Readme.md/" },
-    { srcPath: "/docs/readme.MD", url: "/docs/readme.MD/" },
+    { srcPath: "/docs/Readme", url: "/docs/Readme/" },
+    { srcPath: "/docs/readme", url: "/docs/readme/" },
   ]);
 
   applyReadmeTransform(pages, { prettyUrls: true });
@@ -104,11 +92,13 @@ Deno.test("readme plugin - custom homepage array", () => {
 Deno.test("readme plugin - ordered array first match wins", () => {
   const pages = createMockPages([
     { srcPath: "/docs/README", url: "/docs/README/" },
+    { srcPath: "/docs/HOME", url: "/docs/HOME/" },
   ]);
 
-  applyReadmeTransform(pages, { homepage: ["README.md", "README"] });
+  applyReadmeTransform(pages, { homepage: ["HOME", "README"] });
 
   assertEquals(pages[0].data.url, "/docs/");
+  assertEquals(pages[1].data.url, "/docs/");
 });
 
 Deno.test("readme plugin - skips non-matching source paths", () => {
@@ -141,7 +131,7 @@ function applyReadmeTransform(
 ) {
   const {
     prettyUrls = true,
-    homepage = ["readme.md", "readme.txt", "README"],
+    homepage = ["README"],
     exclude = [],
     include = [],
   } = options;

--- a/plugins/readme/test/readme_test.ts
+++ b/plugins/readme/test/readme_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals, assertThrows } from "https://deno.land/std@0.201.0/assert/mod.ts";
-import readme, { defaults, findHomepageMatch, getBasename, getDirPath, buildUrl, isExcluded, hasExplicitUrl } from "../readme.ts";
+import readme, { defaults, findHomepageMatch, getBasename, getDirPath, buildUrl, isExcluded, hasExplicitUrl, computeAutoUrl } from "../readme.ts";
 import type { Page } from "lume/core/file.ts";
 import type Site from "lume/core/site.ts";
 
@@ -105,32 +105,47 @@ Deno.test("isExcluded - corrected path doesn't match partial directories", () =>
 
 Deno.test("hasExplicitUrl - auto-generated pretty URL", () => {
   const page = { data: { url: "/docs/README/" } } as Page;
-  assertEquals(hasExplicitUrl(page, "README"), false);
+  assertEquals(hasExplicitUrl(page, "/docs/README", true), false);
 });
 
 Deno.test("hasExplicitUrl - auto-generated non-pretty URL", () => {
   const page = { data: { url: "/docs/README.html" } } as Page;
-  assertEquals(hasExplicitUrl(page, "README"), false);
+  assertEquals(hasExplicitUrl(page, "/docs/README", false), false);
 });
 
 Deno.test("hasExplicitUrl - root auto-generated URL", () => {
   const page = { data: { url: "/README/" } } as Page;
-  assertEquals(hasExplicitUrl(page, "README"), false);
+  assertEquals(hasExplicitUrl(page, "/README", true), false);
 });
 
-Deno.test("hasExplicitUrl - explicit URL not matching basename", () => {
+Deno.test("hasExplicitUrl - explicit URL not matching auto pattern", () => {
   const page = { data: { url: "/my-custom/" } } as Page;
-  assertEquals(hasExplicitUrl(page, "README"), true);
+  assertEquals(hasExplicitUrl(page, "/docs/README", true), true);
 });
 
 Deno.test("hasExplicitUrl - URL containing basename as substring", () => {
   const page = { data: { url: "/docs-readme/" } } as Page;
-  assertEquals(hasExplicitUrl(page, "README"), true);
+  assertEquals(hasExplicitUrl(page, "/docs/README", true), true);
+});
+
+Deno.test("hasExplicitUrl - explicit URL with basename but different path", () => {
+  const page = { data: { url: "/something/README/" } } as Page;
+  assertEquals(hasExplicitUrl(page, "/foo/README", true), true);
 });
 
 Deno.test("hasExplicitUrl - case insensitive for auto-generated", () => {
   const page = { data: { url: "/docs/Readme/" } } as Page;
-  assertEquals(hasExplicitUrl(page, "README"), false);
+  assertEquals(hasExplicitUrl(page, "/docs/README", true), false);
+});
+
+Deno.test("computeAutoUrl - pretty URLs", () => {
+  assertEquals(computeAutoUrl("/docs/README", true), "/docs/README/");
+  assertEquals(computeAutoUrl("/README", true), "/README/");
+});
+
+Deno.test("computeAutoUrl - non-pretty URLs", () => {
+  assertEquals(computeAutoUrl("/docs/README", false), "/docs/README.html");
+  assertEquals(computeAutoUrl("/README", false), "/README.html");
 });
 
 Deno.test("readme plugin - transforms README URLs via preprocess", () => {
@@ -204,6 +219,23 @@ Deno.test("readme plugin - preserves explicit non-pretty URLs", () => {
   capturedFn!(pages);
 
   assertEquals(pages[0].data.url, "/my-custom.html");
+});
+
+Deno.test("readme plugin - preserves explicit URL with basename in different path", () => {
+  let capturedFn: (pages: { src: { path: string }; data: { url: string; basename?: string } }[]) => void;
+  const site = createMockSite({
+    preprocessFn: (fn) => { capturedFn = fn as typeof capturedFn; },
+  });
+  const plugin = readme();
+  plugin(site as unknown as Site);
+
+  const pages = createMockPages([
+    { srcPath: "/foo/README", url: "/something/README/" },
+  ]);
+
+  capturedFn!(pages);
+
+  assertEquals(pages[0].data.url, "/something/README/");
 });
 
 Deno.test("readme plugin - excludes paths via preprocess", () => {


### PR DESCRIPTION
Replaces manual url() function in _data.ts with a configurable plugin. The homepage option accepts an ordered array of filenames (case insensitive), defaulting to ["readme.md", "readme.txt", "README"].