### PR TITLE
Use remark-highlight-mark instead of custom highlight implementation

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -10,6 +10,7 @@ import rehypeStarryNight from "https://cdn.jsdelivr.net/npm/rehype-starry-night@
 import { all } from "https://cdn.jsdelivr.net/npm/@wooorm/starry-night@3.6.0/+esm";
 import rehypeExtractExcerpt from "https://esm.sh/rehype-extract-excerpt@0.3.1";
 import rehypePicture from "https://esm.sh/rehype-picture@5.0.0";
+import { remarkHighlightMark } from "https://esm.sh/remark-highlight-mark@1.4.0";
 import rehypeImgSize from "https://esm.sh/rehype-img-size@1.0.1";
 import purgecss from "lume/plugins/purgecss.ts";
 import sitemap from "lume/plugins/sitemap.ts";
@@ -51,6 +52,7 @@ site.add([".png", ".jpg"]);
 site.use(remark({
   remarkPlugins: [
     customWikiLinks,
+    remarkHighlightMark,
   ],
   rehypePlugins: [[
     rehypeStarryNight,

--- a/custom-wiki-links.ts
+++ b/custom-wiki-links.ts
@@ -12,7 +12,6 @@ interface ASTNode {
     hName?: string;
   };
   _wikiLinksReplacement?: ASTNode[];
-  _highlightReplacement?: ASTNode[];
 }
 
 interface TextNode extends ASTNode {
@@ -171,68 +170,13 @@ export function customWikiLinks() {
     }
   }
 
-  function processHighlights(node: ASTNode): void {
-    if (node.type === 'text' && typeof node.value === 'string' && !isInCodeContext(node)) {
-      const highlightRegex = /==([^=]+)==/g;
-      const matches = [...node.value.matchAll(highlightRegex)];
-      
-      if (matches.length > 0) {
-        const newNodes: ASTNode[] = [];
-        let lastIndex = 0;
-        
-        for (const match of matches) {
-          const fullMatch = match[0];
-          const highlightText = match[1];
-          const matchIndex = match.index!;
-          
-          // Add text before the highlight
-          if (matchIndex > lastIndex) {
-            newNodes.push({
-              type: 'text',
-              value: node.value.slice(lastIndex, matchIndex)
-            });
-          }
-          
-          // Add the highlight (using mark element)
-          newNodes.push({
-            type: 'emphasis', // Using emphasis for now as remark doesn't have native mark support
-            data: {
-              hName: 'mark'
-            },
-            children: [{
-              type: 'text',
-              value: highlightText
-            }]
-          });
-          
-          lastIndex = matchIndex + fullMatch.length;
-        }
-        
-        // Add remaining text
-        if (lastIndex < node.value.length) {
-          newNodes.push({
-            type: 'text',
-            value: node.value.slice(lastIndex)
-          });
-        }
-        
-        // Mark this node for replacement
-        node._highlightReplacement = newNodes;
-      }
-    }
-  }
-
+    
   function processNode(node: ASTNode, parent: ASTNode | null = null): void {
     // Set parent reference for context checking
     node.parent = parent;
     
     // Process wiki links first
     processWikiLinks(node);
-    
-    // Process highlights second (only if no wiki link replacement)
-    if (!node._wikiLinksReplacement) {
-      processHighlights(node);
-    }
     
     // Process children
     if (node.children) {
@@ -246,9 +190,6 @@ export function customWikiLinks() {
         if (child._wikiLinksReplacement) {
           node.children.splice(i, 1, ...child._wikiLinksReplacement);
           delete child._wikiLinksReplacement;
-        } else if (child._highlightReplacement) {
-          node.children.splice(i, 1, ...child._highlightReplacement);
-          delete child._highlightReplacement;
         }
       }
     }


### PR DESCRIPTION
- Remove highlight feature (==text==) from custom-wiki-links.ts
- Add remark-highlight-mark@1.4.0 plugin to handle ==text== syntax
- custom-wiki-links.ts now only handles wiki links ([[link]])
- Reduced custom-wiki-links.ts from 260 to 201 lines
- Site builds successfully (360 files generated)