### PR TITLE
Review Android Setup Guide

### DIFF
--- a/uses/android.md
+++ b/uses/android.md
@@ -2,17 +2,17 @@
 
 ## No Google Account
 
-I do not sign in to a Google Account on the phone, because I dislike the idea of link a device to an online account.
+I do not sign in to a Google Account on the phone, because I dislike the idea of linking a device to an online account.
 
 Without a Google Account, I cannot install applications via Google Play Store.
-Thus, I use [F-Droid] (free and open source) and [APKPure] (apk files identical to those in the Google Play Store) to install applications.
+Thus, I use [F-Droid] (free and open source) and [APKPure] (for apps that are not on F-Droid) to install applications.
 
 [F-Droid]: https://f-droid.org/
 [APKPure]: https://apkpure.com/
 
 ## Applications
 
-- Application market: F-Droid
+- Application market: F-Droid and APKPure
 - Browser: [DuckDuckGo Privacy Browser] and [Vivaldi] (with user activity tracking disabled by default)
 
 [DuckDuckGo Privacy Browser]: https://duckduckgo.com/app-mobile


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Review and light cleanup of `uses/android.md`.

## Findings

1. **Grammar** — “the idea of link a device” → “linking”
2. **Inconsistency** — the install section names both F-Droid and APKPure, but Applications only listed F-Droid
3. **Overstated claim** — “apk files identical to those in the Google Play Store” is not something we can assert; APKPure has had malware incidents, so the parenthetical now just states why it is used

## Left as-is

- Vivaldi’s “user activity tracking disabled by default” — matches Vivaldi’s own privacy stance (they do not profile browsing), not the optional tracker-blocker feature
- No restore of Simple Notes / WireGuard (removed intentionally in 2022)
- DuckDuckGo / Vivaldi / F-Droid / APKPure links still resolve

## Diff summary

- Grammar fix in the No Google Account section
- APKPure described as the source for apps not on F-Droid
- Applications list includes both markets
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f67a6-652e-7cf7-9250-909910e10263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f67a6-652e-7cf7-9250-909910e10263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

