### PR TITLE
Set up Cursor Cloud dev environment (Deno + Lume)

### DIFF
--- a/.plans/TODO.md
+++ b/.plans/TODO.md
@@ -71,6 +71,23 @@ Features implemented:
 
 Discovered while setting up the Cursor Cloud dev environment (Deno 2.9.3, Lume v3.0.4).
 
+## Reproduction environment
+
+| Component | Version / value |
+|-----------|-----------------|
+| Host | Cursor Cloud VM (Docker container inside a Firecracker microVM) |
+| OS | Ubuntu 24.04.4 LTS (x86_64) |
+| Kernel | `6.12.94+` |
+| CPU / RAM | 4 vCPU (Intel Xeon) / ~15 GiB |
+| Deno | 2.9.3 (stable, x86_64-unknown-linux-gnu) |
+| Lume | v3.0.4 (`deno.json` import map) |
+| tmux | 3.5a (interactive pane = pty; where the serve hang reproduces) |
+| Desktop (for GUI/VNC) | XFCE 4 on `Xtigervnc`, `DISPLAY=:1`, 1920x1200 |
+
+Notes for reproduction:
+- The non-TTY runner used by the Cursor agent Shell tool reports `TERM=dumb`; serve **works** there. The hang shows up when serve is launched inside a tmux pane (proper pty, `TERM=tmux-256color`/`screen-256color`).
+- No `package.json`; deps are Deno URL/npm imports cached on first run. Warm the cache with `deno cache _config.ts gemini.ts gemini-converter.ts tasks/gmi.ts`.
+
 ## 1. Lume serve worker swallows errors (silent hang)
 
 **Symptom:** When `deno task serve` fails at build/serve time, it produces **no error message** — the process just hangs and never opens a port.

--- a/.plans/TODO.md
+++ b/.plans/TODO.md
@@ -64,3 +64,51 @@ Features implemented:
 - Conditional 404 based on `MIRROR_LOCATION` env
 - Custom page types (`article`, `zettel`) for feed filtering
 - Git Date (simple preprocess hook)
+
+---
+
+# Known Issues / Dev-Env Notes
+
+Discovered while setting up the Cursor Cloud dev environment (Deno 2.9.3, Lume v3.0.4).
+
+## 1. Lume serve worker swallows errors (silent hang)
+
+**Symptom:** When `deno task serve` fails at build/serve time, it produces **no error message** — the process just hangs and never opens a port.
+
+**Root cause:** Serve mode runs the build inside a Web Worker. In `cli/build_worker.ts` the message handler invokes the build without catching rejections:
+
+```ts
+addEventListener("message", (event) => {
+  const { type } = event.data;
+  if (type === "build" || type === "rebuild") {
+    return build(event.data); // async fn, not awaited, no .catch
+  }
+  // ...
+});
+```
+
+`build()` is `async`, so a throw inside it (e.g. `server.start()` → `Deno.serve` failing to bind) becomes an **unhandled promise rejection inside the worker**. `build_worker.ts` registers no `unhandledrejection`/`onerror` handler, and `watcher.start()` has already kept the event loop alive, so the worker neither crashes visibly nor serves. Net effect: a silent hang.
+
+**Verified:** replicating the worker with a `try/catch` around `server.start()` surfaces the real error (`AddrNotAvailable` in the non-serve/bad-bind case), while the real `build_worker.ts` prints nothing.
+
+**Suggested fixes (upstream Lume):**
+- Wrap `build()` in `.catch` in the message handler, or make the handler `async` and `await` it inside a `try/catch`.
+- Add a worker-level `addEventListener("unhandledrejection", …)` that logs and/or `postMessage`s the error back to the parent.
+- Parent (`cli/build.ts`) could surface `worker.onerror` / `onmessageerror` to the console.
+
+**Note:** In normal usage `deno task serve` binds `localhost:3000` and works (serve mode ignores the `location` in `_config.ts`). The `mmap.page:443` address only appears when the build runs **without** `-s` (non-serve branch of `getOptionsFromCli`), which is not how serve runs.
+
+## 2. `deno task serve` intermittently hangs under an interactive TTY
+
+**Symptom:** Launching `deno task serve` (or `deno task lume -s …`) inside an **interactive terminal / tmux pane** intermittently hangs during startup — stuck right after Deno's `--unstable` warning, before any build output, no server, no error.
+
+**Observations:**
+- Run **non-interactively** (output redirected to a file, or via a non-TTY runner) → builds and serves `localhost:3000` reliably.
+- Run in an interactive tmux pane (a pty) → frequently hangs; observed with and without `--hostname 0.0.0.0 --port 3000`, so those flags are **not** a reliable workaround.
+- Could not isolate a single deterministic trigger; behaves like a startup race that a controlling TTY makes far more likely. Likely a Lume-serve-worker × Deno 2.9.3 × TTY interaction. Issue #1 above is why it's silent rather than diagnosable.
+
+**Workaround:** start the dev server non-interactively, e.g. redirect output to a log file / let a non-TTY runner background it, then `curl http://localhost:3000/`.
+
+**Related sandbox caveat:** in the Cursor Cloud VM, detached processes (`nohup`/`setsid … &`) are reaped when the launching shell call ends, so a persistent server needs a session manager — but tmux panes (TTY) trigger the hang above. Practical path: run serve via a non-TTY background runner and keep the call alive long enough for startup.
+
+**TODO:** file/track upstream Lume issues for #1 (swallowed worker errors) and #2 (TTY startup hang); minimal repro for #2 still needed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,8 @@ Standard commands (see `deno.json` and `.github/workflows/deno.yml`):
 - Lint: `deno lint` — reports **pre-existing** `no-explicit-any` violations; CI only runs `deno test -A` and `deno task build`, not lint.
 - Gemini/Gemtext build (optional): `deno task gmi`
 
-Non-obvious gotcha — running the dev server:
+Running the dev server:
 
-- `deno task serve` (i.e. `lume -s`) derives the local server host/port from the `location` in `_config.ts` (`https://mmap.page`, so hostname `mmap.page` port `443`). In the cloud VM that address is not bindable, so `Deno.serve` throws `AddrNotAvailable (os error 99)`. The serve build worker swallows this as a silent unhandled rejection, so **there is no error message — the process just hangs and never opens a port.**
-- Fix: always override the bind address, e.g. `deno task lume -s --hostname 0.0.0.0 --port 3000` (or `--location http://localhost:3000/`). Then the site is reachable at `http://localhost:3000/`. Use `127.0.0.1`/`localhost` in `curl`; `0.0.0.0` is only the bind address.
+- `deno task serve` builds the site and serves it at `http://localhost:3000/`. Serve mode binds `localhost`, **not** the `location` in `_config.ts` (`https://mmap.page`) — that `location` only affects generated/canonical URLs (feeds, sitemap), not the local server. No `--hostname`/`--port` override is needed. Use `127.0.0.1`/`localhost` in `curl`.
+- Non-obvious gotcha: launching `deno task serve` inside an **interactive terminal / tmux pane (a TTY)** has intermittently hung during startup in this VM — the build finishes but the server never opens a port and **no error is printed**. Run it non-interactively instead (let the agent Shell tool background it, or redirect output to a file). `--hostname`/`--port` flags do **not** reliably avoid the hang.
+- Why it's silent: Lume runs the serve build in a Web Worker (`cli/build_worker.ts`) that fires the async build without a `.catch` and installs no `unhandledrejection` handler, so any serve-time error surfaces as a silent hang rather than a message.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,3 +77,19 @@ Assisted-by: Cursor:cursor-grok-4.5
 - Always write `Assisted-by` for **this** commit from the agent/model that materially helped. Do **not** copy an `Assisted-by` line from `git log`, prior commits, or commit-message examples — those often name a different model.
 - `MODEL_VERSION` must match the model that produced the changes (e.g. the model named in the current chat / system identity), not whatever appeared last in history.
 - The human author is responsible for reviewing all AI-assisted changes before pushing commits or creating pull requests.
+
+## Cursor Cloud specific instructions
+
+This is a single [Deno](https://deno.land) + [Lume](https://lume.land) static site. There is no `package.json`; the runtime is Deno and all tasks live in `deno.json` (`build`, `serve`, `gmi`). Deno is preinstalled at `~/.deno/bin` — add it to `PATH` if a shell doesn't pick it up (`export PATH="$HOME/.deno/bin:$PATH"`). Dependencies are URL/npm imports resolved and cached by Deno on first run; there is no separate install step.
+
+Standard commands (see `deno.json` and `.github/workflows/deno.yml`):
+
+- Build: `deno task build` (outputs to `_site/`)
+- Test: `deno test -A`
+- Lint: `deno lint` — reports **pre-existing** `no-explicit-any` violations; CI only runs `deno test -A` and `deno task build`, not lint.
+- Gemini/Gemtext build (optional): `deno task gmi`
+
+Non-obvious gotcha — running the dev server:
+
+- `deno task serve` (i.e. `lume -s`) derives the local server host/port from the `location` in `_config.ts` (`https://mmap.page`, so hostname `mmap.page` port `443`). In the cloud VM that address is not bindable, so `Deno.serve` throws `AddrNotAvailable (os error 99)`. The serve build worker swallows this as a silent unhandled rejection, so **there is no error message — the process just hangs and never opens a port.**
+- Fix: always override the bind address, e.g. `deno task lume -s --hostname 0.0.0.0 --port 3000` (or `--location http://localhost:3000/`). Then the site is reachable at `http://localhost:3000/`. Use `127.0.0.1`/`localhost` in `curl`; `0.0.0.0` is only the bind address.

--- a/movies/notes.csv
+++ b/movies/notes.csv
@@ -1,6 +1,6 @@
 id,note
 300581,This movie inspires me deeply to keep running and stay active in everyday life.
-294607,While shooting on digital cameras, the cinematography is still beautiful but overall this movie offers nothing new to me. It just resembles several movies I like.
+294607,"While shooting on digital cameras, the cinematography is still beautiful but overall this movie offers nothing new to me. It just resembles several movies I like."
 317952,This movie is shot on film and has a vibe of old movies. The plot is not that convincing though.
 266042,A socalled BL movies with Drama overflow.
 266046,"Brilliantly revals the emotional connection between riots in 1967 and 2019. Compared to Revolution of Our Times directed by a Christian, Blue Island clings to a more depressingly recurring view."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this Deno + Lume static site so tests, lint, build, and the dev server all run in Cursor Cloud.

While bringing up the environment I hit one genuine, pre-existing breakage (master CI is currently red for the same reason):

- **Build was failing** on `/movies/`: the note for movie `294607` in `movies/notes.csv` had an **unquoted comma**, so the CSV parser saw 3 fields instead of 2 and threw. Quoted the field like every other multi-comma note. This is what breaks the latest `master` CI runs (`Deno` and `Deploy to GitHub Pages`).

No application/source logic was changed beyond the one-field CSV data fix required to make the site build.

### Dev-server note (corrected)

An earlier revision of this PR claimed `deno task serve` fails by binding to `mmap.page:443`. On closer testing that was wrong: it was an artifact of running Lume's build **without** `-s`. In serve mode Lume binds `localhost:3000` (the `location` in `_config.ts` only affects canonical/feed URLs), and plain `deno task serve` works headless. The real, documented caveat is that launching serve inside an interactive TTY/tmux pane intermittently hangs with no error (Lume's `cli/build_worker.ts` swallows worker errors); run it non-interactively instead. AGENTS.md has been updated to reflect this.

## Changes

- `:bug:` `movies/notes.csv`: quote the note containing a comma so the CSV parses and the build succeeds.
- `:memo:` `AGENTS.md`: add `## Cursor Cloud specific instructions` (Deno/Lume overview, standard commands, and the corrected dev-server startup caveat).

## Environment

- Update script (dependency refresh on startup): `deno cache _config.ts gemini.ts gemini-converter.ts tasks/gmi.ts` (Deno preinstalled at `~/.deno/bin`; deps are URL/npm imports cached on demand — no package-manager install step).

## Verification

| Check | Command | Result |
|-------|---------|--------|
| Lint | `deno lint` | Runs; 52 pre-existing `no-explicit-any` violations (not in CI) |
| Test | `deno test -A` | 51 passed / 0 failed |
| Build | `deno task build` | 362 files generated |
| Run (dev) | `deno task serve` | Serves at `http://localhost:3000/`; homepage, `/movies/`, and a live-reloaded new page all return 200 |

Hello-world: created a temp markdown page and confirmed the running watcher rebuilt it and the custom wiki-links plugin resolved `[[README]]` → `<a href="/README/">` (temp file removed, not committed).

[lume_dev_server_demo.mp4](https://cursor.com/agents/bc-956e10af-1545-4ea1-8283-349641135f81/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flume_dev_server_demo.mp4)

[Homepage](https://cursor.com/agents/bc-956e10af-1545-4ea1-8283-349641135f81/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage.webp)
[Movies page table](https://cursor.com/agents/bc-956e10af-1545-4ea1-8283-349641135f81/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmovies_page.webp)
[Hello Cursor page with wiki link](https://cursor.com/agents/bc-956e10af-1545-4ea1-8283-349641135f81/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_cursor_page.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-956e10af-1545-4ea1-8283-349641135f81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-956e10af-1545-4ea1-8283-349641135f81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

